### PR TITLE
Add expiry to PR instances.

### DIFF
--- a/clusternator.json
+++ b/clusternator.json
@@ -1,6 +1,7 @@
 {
   "projectId": "the-clusternator",
   "private": ".private",
+  "prTTL": 259200000,
   "clusternatorDir": ".clusternator",
   "deploymentsDir": ".private/deployments",
   "useInternalSSL": false

--- a/docs/config.json
+++ b/docs/config.json
@@ -2,6 +2,7 @@
   "description":"Update this with production values, or use a config.local.json (same structure as this file)",
   "adminEmail":"user@example.com",
   "config.hasReadLetsEncryptTOS": false,
+  "prTTL": 259200000,
   "port":9090,
   "portSSL":3000,
   "setupRootPass": "super secret",

--- a/src/aws/ec2Manager.js
+++ b/src/aws/ec2Manager.js
@@ -5,6 +5,7 @@ const SETUP_SSH = 'mkdir -p /home/ec2-user/.ssh';
 const CHOWN_SSH ='chown -R ec2-user:ec2-user /home/ec2-user/.ssh && chmod -R ' +
   'go-rwx /home/ec2-user/.ssh';
 const OUTPUT_SSH = '>> /home/ec2-user/.ssh/authorized_keys';
+const Config = require('../config');
 const configAttributes = ['clusterName', 'sgId', 'subnetId', 'pid'];
 const prConfigAttributes = configAttributes.concat(['pr']);
 const deploymentConfigAttributes = configAttributes.concat(
@@ -197,6 +198,8 @@ function getEC2Manager(ec2, vpcId) {
    * @returns {*}
    */
   function tagPrInstance(instance, pr, pid) {
+    const config = Config();
+
     return common.awsTagEc2(ec2, instance.InstanceId, [{
       Key: constants.CLUSTERNATOR_TAG,
       Value: 'true'
@@ -206,6 +209,9 @@ function getEC2Manager(ec2, vpcId) {
     }, {
       Key: constants.PROJECT_TAG,
       Value: pid + ''
+    }, {
+      Key: constants.EXPIRES_TAG,
+      Value: (Date.now() + (config.prTTL || 259200000)) + ''
     }]);
   }
 

--- a/src/aws/instance-reaper.js
+++ b/src/aws/instance-reaper.js
@@ -1,0 +1,25 @@
+'use strict';
+
+const EC2_BILLING_PERIOD  = 10000 * 60 * 60;
+const config = require('../config')();
+const pm = require('./project-init')(config);
+
+var intervalID;
+
+function start() {
+  if (!intervalID) {
+    intervalID = setInterval(pm.destroyExpiredPRs, EC2_BILLING_PERIOD);
+  }
+}
+
+function stop() {
+  if (intervalID) {
+    clearInterval(intervalID);
+    intervalID = undefined;
+  }
+}
+
+module.exports = {
+  start,
+  stop
+};

--- a/src/constants.js
+++ b/src/constants.js
@@ -3,11 +3,12 @@
 const CLUSTERNATOR_PREFIX = 'clusternator';
 const DELIM = '-';
 const CLUSTERNATOR_TAG = CLUSTERNATOR_PREFIX + DELIM + 'created';
-const PROJECT_TAG = CLUSTERNATOR_PREFIX + DELIM + 'project';
-const PR_TAG = CLUSTERNATOR_PREFIX + DELIM + 'pr';
 const DEPLOYMENT_TAG = CLUSTERNATOR_PREFIX + DELIM + 'deployment';
+const EXPIRES_TAG = CLUSTERNATOR_PREFIX + DELIM + 'expires';
+const PROJECT_TAG = CLUSTERNATOR_PREFIX + DELIM + 'project';
+const PROJECT_USER_TAG = CLUSTERNATOR_PREFIX + DELIM + 'project' + DELIM;
+const PR_TAG = CLUSTERNATOR_PREFIX + DELIM + 'pr';
 const SHA_TAG = CLUSTERNATOR_PREFIX + DELIM + 'sha';
-const PROJECT_USER_TAG = 'clusternator-project-';
 /**const NOTEconst EC2const AMI'sconst areconst regionconst specificconst */
 //const AWS_DEFAULT_EC2_AMI = 'ami-8da458e6';
 //const AWS_DEFAULT_EC2_AMI = 'ami-e2b1f988';
@@ -53,9 +54,10 @@ const constants = Object.freeze({
   }],
   CLUSTERNATOR_PREFIX,
   CLUSTERNATOR_TAG,
+  DEPLOYMENT_TAG,
+  EXPIRES_TAG,
   PROJECT_TAG,
   PR_TAG,
-  DEPLOYMENT_TAG,
   SHA_TAG,
   SSH_PUBLIC_PATH,
   AWS_DEFAULT_EC2: Object.freeze({

--- a/src/server/main.js
+++ b/src/server/main.js
@@ -16,6 +16,7 @@ const loggers = require('./loggers');
 const log = loggers.logger;
 const prHandler = require('./pullRequest');
 const getProjectManager = require('../aws/project-init');
+const instanceReaper = require('../aws/instance-reaper');
 const pushHandler = require('./push');
 const authentication = require('./auth/authentication');
 const githubAuthMiddleware = require('./auth/githubHook');
@@ -88,6 +89,7 @@ function createServer(pm, config) {
   hostInfo();
   const app = express();
   const leApp = startSSL(app, config);
+  instanceReaper.start();
 
   initExpress(app);
   /**

--- a/src/skeletons/clusternator-json-skeleton.js
+++ b/src/skeletons/clusternator-json-skeleton.js
@@ -9,5 +9,6 @@ module.exports = Object.freeze({
 
   // These are defaults
   deploymentsDir: path.join('.private', 'deployments'),
-  useInternalSSL: false
+  useInternalSSL: false,
+  prTTL: 1000 * 60 * 60 * 24 * 3 // 3 days
 });


### PR DESCRIPTION
 - Tag PR instances with expiry time.
 - Add `destroyExpiredPRs` to destroy PR instances which have expired.
 - Poll `destroyExpiredPRs` regularly to clean up expired PR instances.

Resolves #53 