### PR TITLE
Generic Dynamo Based Hash Table Implementation

### DIFF
--- a/docs/_layouts/guide-dev.html
+++ b/docs/_layouts/guide-dev.html
@@ -1,0 +1,15 @@
+---
+layout: default
+---
+<article class="post">
+
+  <header class="post-header">
+    <h1 class="post-title">{{ page.title }}</h1>
+  </header>
+
+  <div class="post-content">
+    <i><a href="../dev" title="Developer's Guide">Developer's Guide</a></i>
+    {{ content }}
+  </div>
+
+</article>

--- a/docs/pages/guide/dev/source.md
+++ b/docs/pages/guide/dev/source.md
@@ -1,0 +1,34 @@
+---
+layout: guide-dev
+title: Navigating The Source
+permalink: /guide/dev/source
+---
+
+Complete [API documentation](/api/ "API Documentation") is available.  This 
+guide aims to help developers navigate the API documentation and the actual
+source from which it is generated.
+
+The source code is divided into the following modules:
+
+- AWS API `src/aws/` which provides a promise based interface for dealing with
+Amazon Web Services.  AWS is the first (and currently only) cloud service
+provider supported by Clusternator
+- Clusternator API `src/clusternator/*` which provides a promise based _client_ 
+interface for deailing with a Clusternator server interface which in turn maps 
+to a cloud service API.
+- Clusternator public APIs `src/api/*` which is a collection of API's for use
+by Clusternator users or consumers of the Clusternator.  These public API's are
+divided into:
+    - CLI the command line api
+    - REST the RESTful (web server) API
+    - project-fs the API for managing source code based project files
+    - js the API exposed by The Clusternator node module. This API essentially
+      maps calls from its siblings into the system
+- CLI Wrappers `src/cli-wrappers` CLI based commands wrapped into promise based 
+node processes
+- The Clusternator Server `src/server` which is where the Express based server
+code lives
+- There are also common scripts located in `src/*` as well as a few
+"accidentals" like `bin-src/*`
+
+

--- a/docs/pages/guide/developing-and-contributions.md
+++ b/docs/pages/guide/developing-and-contributions.md
@@ -51,6 +51,8 @@ for your browser.  Please see: [zenhub.io](https://www.zenhub.io/ "Zen Hub")_
 
 ## Code
 
+[Navigating The Source](source "Navigating The Source")
+
 All code is in `src/`. The CLI entry point is `bin/clusternator-cli.js`,
 but includes from `lib/` (the compile destination).
 

--- a/spec/repl/ddb.spec.js
+++ b/spec/repl/ddb.spec.js
@@ -1,0 +1,17 @@
+'use strict';
+
+const R = require('ramda');
+
+var setup = require('./setup');
+var util = require(setup.path('util'));
+var ddb = require(setup.path('aws', 'ddb', 'hash-table.js'));
+
+function ddbAwsPartial(fn) {
+  if (typeof fn === 'function') {
+    return R.partial(fn, {ddb: util.makePromiseApi(setup.getDDB())});
+  }
+}
+
+const partialedDDB = R.mapObjIndexed(ddbAwsPartial, ddb);
+
+module.exports = partialedDDB;

--- a/spec/repl/index.js
+++ b/spec/repl/index.js
@@ -23,6 +23,7 @@ function logError(e) {
 module.exports = {
   acl: require('./acl.spec'),
   cluster: require('./cluster.spec'),
+  ddb: require('./ddb.spec'),
   deployment: require('./deployment.spec'),
   ec2: require('./ec2.spec'),
   ecr: require('./ecr.spec'),

--- a/spec/repl/setup.js
+++ b/spec/repl/setup.js
@@ -42,7 +42,18 @@ function getRoute53() {
 
 function getDDB() {
   var config = c();
-  return new a.DynamoDB(config.awsCredentials);
+  let nodeGt10Config =  {
+    httpOptions: {
+      agent: new https.Agent({
+        ciphers: 'ALL',
+        secureProtocol: 'TLSv1_method'
+      })
+    }
+  };
+  Object.keys(config.awsCredentials).forEach((attr) => {
+    nodeGt10Config[attr] = config.awsCredentials[attr];
+  });
+  return new a.DynamoDB(nodeGt10Config);
 }
 
 function makePath() {

--- a/src/aws/ddb/hash-table.js
+++ b/src/aws/ddb/hash-table.js
@@ -1,0 +1,287 @@
+'use strict';
+
+const WRITE_UNITS = 10;
+const READ_UNITS = 10;
+const MAX_LISTED_RESULTS = 100;
+
+const Q = require('q');
+const R = require('ramda');
+
+const clusternatePrefixString = require('../../resource-identifier')
+  .clusternatePrefixString;
+
+module.exports = {
+  accessor,
+  create,
+  destroy,
+  hashTable,
+  key,
+  list: listAllTables,
+  helpers: {
+    checkIfTableExists,
+    checkAndWrite,
+    makeDdbItem,
+    read,
+    write
+  }
+};
+
+/**
+ * Returns a function that will get/set on the table/id provided.
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @param {string} id
+ * @returns {function(string=)}
+ */
+function key(aws, table, id) {
+  return R.partial(accessor, [ aws, table, id ]);
+}
+
+/**
+ * Returns a function that will get/set
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @returns {function(string, string=)}
+ */
+function hashTable(aws, table) {
+  return R.partial(accessor, [ aws, table ]);
+}
+
+/**
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @param {string} key
+ * @param {*} value
+ * @returns {Function}
+ */
+function accessor(aws, table, key, value) {
+
+  if(value === undefined && key) {
+    key += '';
+    return read(aws, table, key);
+  } else if (key) {
+    key += '';
+    return checkAndWrite(aws, table, key, value);
+  } else {
+    throw new TypeError('shit\'s crazy');
+  }
+}
+
+/**
+ * @param {string} key
+ * @param {*} value
+ * @returns {{ id: { S: string }, value: { S: string }}}
+ */
+function makeDdbItem(key, value) {
+  if (typeof value !== 'string') {
+    value = JSON.stringify(value);
+  }
+  return {
+    id: {
+      S: key
+    },
+    value: {
+      S: value
+    }
+  };
+}
+
+/**
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @param {string} key
+ * @param {*} value
+ * @returns {writeToAws}
+ * @throws {TypeError}
+ */
+function write(aws, table, key, value) {
+  if (!table || !key) {
+    throw new TypeError('write requires a table, key, and value');
+  }
+  value = value || '';
+  /**
+   * @returns {Promise}
+   */
+  function writeToAws() {
+    return aws.ddb.putItem({
+      TableName: clusternatePrefixString(table),
+      Item: makeDdbItem(key, value)
+    });
+  }
+  return writeToAws;
+}
+
+/**
+ * @param {AwsWrapper} aws
+ * @param {string=} lastName
+ * @returns {promiseToListTables}
+ */
+function listAllTables(aws, lastName) {
+  /**
+   * @returns {Promise.<Array.<string>>}
+   */
+  function promiseToListTables() {
+    const listParams = {};
+    if (lastName) {
+      listParams.ExclusiveStartTableName = lastName;
+    }
+    return aws.ddb.listTables(listParams)
+      .then((data) => {
+        if (!data.TableNames) {
+          return Q.reject(new Error('AWS Result missing TableNames'));
+        }
+        if (data.TableNames.length >= MAX_LISTED_RESULTS) {
+          const lastTable = data.TableNames[data.TableNames.length - 1];
+
+          return listAllTables(aws, lastTable)()
+            .then((list) => data.TableNames.concat(list));
+        }
+        return data.TableNames;
+      });
+  }
+  return promiseToListTables;
+}
+
+/**
+ * Returns a promise returning function that checks if a table exists
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @returns {promiseToCheckIfTableExists}
+ * @throws {TypeError}
+ */
+function checkIfTableExists(aws, table) {
+  if (!table) {
+    throw new TypeError('checkIfTableExists requires a table name');
+  }
+  /**
+   * @returns {Promise<boolean>}
+   */
+  function promiseToCheckIfTableExists() {
+    return listAllTables(aws)()
+      .then((list) => list.indexOf(clusternatePrefixString(table)) !== -1);
+  }
+  return promiseToCheckIfTableExists;
+}
+
+/**
+ * Returns a function that promises to create a hash table
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @returns {promiseToCreate}
+ * @throws {TypeError}
+ */
+function create(aws, table) {
+  if (!table) {
+    throw new TypeError('create requires a table name');
+  }
+  /**
+   * @returns {Promise}
+   */
+  function promiseToCreate() {
+    return aws.ddb.createTable({
+      AttributeDefinitions: [{
+          AttributeName: 'id',
+          AttributeType: 'S'
+        }
+      ],
+      KeySchema: [{
+        AttributeName: 'id',
+        KeyType: 'HASH'
+      }],
+      ProvisionedThroughput: {
+        ReadCapacityUnits: READ_UNITS,
+        WriteCapacityUnits: WRITE_UNITS
+      },
+      TableName: clusternatePrefixString(table)
+    });
+  }
+  return promiseToCreate;
+}
+
+/**
+ * Returns a function that promises to check if a table exists, create it if it
+ * doesn't, and finally, write to it
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @param {string} key
+ * @param {*} value
+ * @returns {promiseToCheckAndWrite}
+ * @throws {TypeError}
+ */
+function checkAndWrite(aws, table, key, value) {
+  if (!table || !key) {
+    throw new TypeError('checkAndWrite requires a table name and key');
+  }
+  /**
+   * @returns {Promise}
+   */
+  function promiseToCheckAndWrite() {
+    return checkIfTableExists(aws, table)()
+      .then((tableExists) => {
+        if (tableExists) {
+          return write(aws, table, key, value)();
+        } else {
+          return create(aws, table)()
+            .then(() => write());
+        }
+      });
+  }
+  return promiseToCheckAndWrite;
+}
+
+/**
+ * @param {string} key
+ * @returns {{ id: { S: string }}}
+ */
+function makeReadKey(key) {
+  return {
+    id: {
+      S: key
+    }
+  };
+}
+
+/**
+ * Returns a function that promises to read a given key
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @param {string} key
+ * @returns {promiseToGetItem}
+ * @throws {TypeError}
+ */
+function read(aws, table, key) {
+  if (!table || !key) {
+    throw new TypeError('read requires a table and a key');
+  }
+  /**
+   * @returns {Promise<string>}
+   */
+  function promiseToGetItem() {
+    return aws.ddb.getItem({
+      TableName: clusternatePrefixString(table),
+      Key: makeReadKey(key)
+    }).then((result) => result.Item.value.S);
+  }
+  return promiseToGetItem;
+}
+
+/**
+ * @param {AwsWrapper} aws
+ * @param {string} table
+ * @returns {promiseToDestroy}
+ * @throws {TypeError}
+ */
+function destroy(aws, table) {
+  if (!table) {
+    throw new TypeError('destroy requires a table');
+  }
+  /**
+   * @returns {Promise}
+   */
+  function promiseToDestroy() {
+    return aws.ddb.deleteTable({
+      TableName: clusternatePrefixString(table)
+    }).then(null, () => {});
+  }
+  return promiseToDestroy;
+}

--- a/src/aws/ddb/hash-table.spec.js
+++ b/src/aws/ddb/hash-table.spec.js
@@ -1,0 +1,273 @@
+'use strict';
+
+const rewire = require('rewire');
+const Q = require('q');
+
+const ht = rewire('./hash-table');
+const C = require('../../chai');
+
+const aws = {};
+
+function initData() {
+  aws.ddb = {
+    listTables: () => Q.resolve({ TableNames: new Array(50) }),
+    deleteTable: () => Q.resolve(),
+    createTable: () => Q.resolve(),
+    getItem: () => Q.resolve(),
+    putItem: () => Q.resolve()
+  };
+}
+
+
+/*global describe, it, expect, beforeEach, afterEach */
+describe('AWS: DDB: HashTable', () => {
+
+  beforeEach(initData);
+
+  describe('accessor function', () => {
+    it('should throw without a key argument', () => {
+      expect(() => ht.accessor(aws, 'someTable')).to.throw(TypeError);
+    });
+
+    it('should return a promise-returning read function', () => {
+      const accessorFunction = ht.accessor(aws, 'test', 'someKey');
+      const accessorPromise = accessorFunction();
+      expect(typeof accessorPromise.then === 'function').to.be.ok;
+    });
+
+    it('should return a promise-returning write function', () => {
+      const accessorFunction = ht.accessor(aws, 'test', 'someKey', 'someVal');
+      const accessorPromise = accessorFunction();
+      expect(typeof accessorPromise.then === 'function').to.be.ok;
+    });
+  });
+
+  describe('checkAndWrite function', () => {
+    it('should return a function', () => {
+      const checkAndWriteFunction = ht.helpers
+        .checkAndWrite(aws, 'test', 'someKey', 77);
+      expect(typeof checkAndWriteFunction === 'function').to.be.ok;
+    });
+
+    it('should throw without a key argument', () => {
+      expect(() => ht.helpers.checkAndWrite(aws, 'someTable')).to
+        .throw(TypeError);
+    });
+
+    it('should throw without a table argument', () => {
+      expect(() => ht.helpers.checkAndWrite(aws)).to.throw(TypeError);
+    });
+
+    it('should return a promise-returning function', () => {
+      aws.ddb.listTables = () => Q.resolve({
+        TableNames: ['a', 'clusternator-test', 'b'] });
+
+      const checkAndWriteFunction = ht.helpers
+        .checkAndWrite(aws, 'test', 'someKey', 41);
+      const checkAndWritePromise = checkAndWriteFunction();
+      expect(typeof checkAndWritePromise.then === 'function').to.be.ok;
+    });
+
+    it('should still return a promise-returning function if table does not ' +
+      'exist', () => {
+      const checkAndWriteFunction = ht.helpers
+        .checkAndWrite(aws, 'test', 'someKey', 41);
+      const checkAndWritePromise = checkAndWriteFunction();
+      expect(typeof checkAndWritePromise.then === 'function').to.be.ok;
+    });
+
+  });
+
+  describe('checkIfTableExists function', () => {
+    it('should return a function', () => {
+      const checkIfTableExistsFunction = ht.helpers
+        .checkIfTableExists(aws, 'test');
+      expect(typeof checkIfTableExistsFunction === 'function').to.be.ok;
+    });
+
+    it('should throw without a table argument', () => {
+      expect(() => ht.helpers.checkIfTableExists(aws)).to.throw(TypeError);
+    });
+
+    it('should resolve false if the table is not found', (done) => {
+      aws.ddb = {
+        listTables: () => Q.resolve({ TableNames: ['a', 'b'] })
+      };
+      const checkIfTableExistsFunction = ht.helpers
+        .checkIfTableExists(aws, 'test');
+
+      checkIfTableExistsFunction()
+        .then((r) => C
+          .check(done, () => expect(r === false).to.be.ok, C.getFail(done)));
+
+    });
+
+    it('should resolve true if the clusternated table is found', (done) => {
+      aws.ddb = {
+        listTables: () => Q.resolve({ TableNames: [
+          'a', 'clusternator-test', 'b'] })
+      };
+      const checkIfTableExistsFunction = ht.helpers
+        .checkIfTableExists(aws, 'test');
+
+      checkIfTableExistsFunction()
+        .then((r) => C
+          .check(done, () => expect(r === true).to.be.ok, C.getFail(done)));
+
+    });
+  });
+
+  describe('write function', () => {
+    it('should return a function', () => {
+      const writeFunction = ht.helpers.write(aws, 'test', 'someKey');
+      expect(typeof writeFunction === 'function').to.be.ok;
+    });
+
+    it('should throw without a key argument', () => {
+      expect(() => ht.helpers.write(aws, 'table')).to.throw(TypeError);
+    });
+
+    it('should throw without a table argument', () => {
+      expect(() => ht.helpers.write(aws)).to.throw(TypeError);
+    });
+
+    it('should return a promise-returning function', () => {
+      const writeFunction = ht.helpers.write(aws, 'test', 'someKey');
+      const writePromise = writeFunction();
+      expect(typeof writePromise.then === 'function').to.be.ok;
+    });
+  });
+
+  describe('read function', () => {
+    it('should return a function', () => {
+      const readFunction = ht.helpers.read(aws, 'test', 'someKey');
+      expect(typeof readFunction === 'function').to.be.ok;
+    });
+
+    it('should throw without a key argument', () => {
+      expect(() => ht.helpers.read(aws, 'table')).to.throw(TypeError);
+    });
+
+    it('should throw without a table argument', () => {
+      expect(() => ht.helpers.read(aws)).to.throw(TypeError);
+    });
+
+    it('should return a promise-returning function', () => {
+      const readFunction = ht.helpers.read(aws, 'test', 'someKey');
+      const readPromise = readFunction();
+      expect(typeof readPromise.then === 'function').to.be.ok;
+    });
+  });
+
+  describe('makeDdbItem function', () => {
+    it('should stringify its given value if it is not a string', () => {
+      const test = ht.helpers.makeDdbItem('5', { test: 3 });
+      expect(JSON.parse(test.value.S).test === 3).to.be.ok;
+    });
+  });
+
+  describe('create function', () => {
+    it('should return a function', () => {
+      const createFunction = ht.create(aws, 'test');
+      expect(typeof createFunction === 'function').to.be.ok;
+    });
+
+    it('should throw without a table argument', () => {
+      expect(() => ht.create(aws)).to.throw(TypeError);
+    });
+
+    it('should return a promise-returning function', () => {
+      const createFunction = ht.create(aws, 'test');
+      const createPromise = createFunction();
+      expect(typeof createPromise.then === 'function').to.be.ok;
+    });
+
+    it('should resolve', (done) => {
+      const createFunction = ht.create(aws, 'test');
+      createFunction()
+        .then(() => C.check(done, () => {
+          expect(true).to.be.ok;
+        }), C.getFail(done));
+    });
+  });
+
+  describe('destroy function', () => {
+    it('should return a function', () => {
+      const destroyFunction = ht.destroy(aws, 'test');
+      expect(typeof destroyFunction === 'function').to.be.ok;
+    });
+
+    it('should throw without a table argument', () => {
+      expect(() => ht.destroy(aws)).to.throw(TypeError);
+    });
+
+    it('should return a promise-returning function', () => {
+      const destroyFunction = ht.destroy(aws, 'test');
+      const destroyPromise = destroyFunction();
+      expect(typeof destroyPromise.then === 'function').to.be.ok;
+    });
+
+    it('should resolve', (done) => {
+      const destroyFunction = ht.destroy(aws, 'test');
+      destroyFunction()
+        .then(() => C.check(done, () => {
+          expect(true).to.be.ok;
+        }), C.getFail(done));
+    });
+
+    it('should resolve pass or fail', (done) => {
+      aws.ddb = {
+        deleteTable: () => Q.reject(new Error('test')),
+      };
+      const destroyFunction = ht.destroy(aws, 'test table');
+      destroyFunction()
+        .then(() => C.check(done, () => {
+          expect(true).to.be.ok;
+        }), C.getFail(done));
+    });
+  });
+
+  describe('list function', () => {
+    it('should return a function', () => {
+      const listFunction = ht.list(aws);
+      expect(typeof listFunction === 'function').to.be.ok;
+    });
+
+    it('should return a promise-returning function', () => {
+      const listFunction = ht.list(aws);
+      const listPromise = listFunction();
+      expect(typeof listPromise.then === 'function').to.be.ok;
+    });
+
+    it('should reject if TableNames not present in result', (done) => {
+      aws.ddb = {
+        listTables: () => Q.resolve(new Array(100))
+      };
+      ht.list(aws)().then(C.getFail(done), (err) => {
+        C.check(done, () => {
+          expect(err instanceof Error).to.be.ok;
+        });
+      });
+    });
+
+    it('should resolve paginated lists', (done) => {
+      let times = 0;
+      aws.ddb = {
+        listTables: () => {
+          if (times) {
+            return Q.resolve({TableNames: ['a', 'b', 'c']});
+          }
+          times += 1;
+          return Q.resolve({ TableNames: (new Array(100)).concat(['z']) });
+        }
+      };
+      const listFunction = ht.list(aws);
+      const listPromise = listFunction();
+      listPromise.then((r) => {
+        C.check(done, () => {
+          expect(Array.isArray(r)).to.be.ok;
+        });
+      }, C.getFail(done));
+    });
+  });
+});


### PR DESCRIPTION
Clusternator now has a dynamo db backed generic key/value hash table system.

The code is well tested wrt unit tests.  Manual REPL tests have been successful but there is a problem doing a write/createTable at the same time.  We should probably just deprecate this feature since we'll be checking table existence on server init anyway