### PR TITLE
Update .gitignore to properly match npm debug logs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 
 node_modules/
 .DS_Store
-npm-debug.log
+npm-debug.log*
 
 # exclude emacs temporary files
 *~


### PR DESCRIPTION
npm will output debug logs in the form `npm-debug.log.3240198371`, the previous rule indicates `npm-debug.log`.