### PR TITLE
Updates to node (dynamic) Dockerfile

### DIFF
--- a/src/api/0.1/project-fs/docker.js
+++ b/src/api/0.1/project-fs/docker.js
@@ -9,6 +9,7 @@ const DOCKERFILE = 'Dockerfile';
 const DOCKERFILE_NODE_LATEST = 'Dockerfile-node-latest';
 const DOCKERFILE_STATIC_LATEST = 'dockerfile-nginx-latest';
 const CLUSTERNATOR_DIR = /\$CLUSTERNATOR_DIR/g;
+const EXTERNAL_PORT = /\$EXTERNAL_PORT/g;
 
 const fs = require('./project-fs');
 const privateFs = require('./private');
@@ -28,9 +29,10 @@ module.exports = {
  *
  * @param {string} clustDir
  * @param {string} dockerType
+ * @param {number=} port
  * @returns {Q.Promise}
  */
-function initializeDockerFile(clustDir, dockerType) {
+function initializeDockerFile(clustDir, dockerType, port) {
   /** @todo do not overwrite existing Dockerfile */
   const template = dockerType === 'static' ?
     DOCKERFILE_STATIC_LATEST : DOCKERFILE_NODE_LATEST;
@@ -38,6 +40,9 @@ function initializeDockerFile(clustDir, dockerType) {
     .findProjectRoot()
     .then((root) => fs.getSkeleton(template)
       .then((contents) => {
+        if (port) {
+          contents = contents.replace(EXTERNAL_PORT, port);
+        }
         contents = contents.replace(CLUSTERNATOR_DIR, clustDir);
         return fs.write(fs.path.join(root, DOCKERFILE), contents);
       }) );

--- a/src/api/0.1/project-fs/init.js
+++ b/src/api/0.1/project-fs/init.js
@@ -34,7 +34,7 @@ function initProject(root, options, skipNetwork) {
       deploymentsFs.init(dDir, projectId, options.ports),
       scriptsFs.init(cDir, options.tld),
       scriptsFs.initOptional(options, root),
-      dockerFs.init(cDir, dockerType)])
+      dockerFs.init(cDir, dockerType, options.ports[0].portInternal)])
     .then(() => {
       if (skipNetwork) {
         util.info('Network Resources *NOT* Checked');

--- a/src/api/0.1/project-fs/skeletons/Dockerfile-node-latest
+++ b/src/api/0.1/project-fs/skeletons/Dockerfile-node-latest
@@ -9,7 +9,7 @@ useradd -u 431 -r -g swuser -d /home/swuser -s /sbin/nologin \
 chown -R swuser:swuser /home/swuser
 
 # install tools
-RUN sudo apt-get update && sudo apt-get install -y git build-essential
+RUN sudo apt-get update && sudo apt-get install -y git
 
 # setup the application
 RUN mkdir /home/app
@@ -22,7 +22,7 @@ RUN cd /home/app/; npm set progress=false; npm install
 
 
 ## Expose the ports
-EXPOSE 3000
+EXPOSE $EXTERNAL_PORT
 
 USER swuser
 CMD ["/home/app/$CLUSTERNATOR_DIR/serve.sh"]


### PR DESCRIPTION
- Dockerfile no longer installs build-essentials (done in base)
- The first external port specified in `clusternator init` is now mapped to the Dockerfile