### PR TITLE
AWS stability updates 1

### DIFF
--- a/src/aws/aws-constants.js
+++ b/src/aws/aws-constants.js
@@ -24,6 +24,9 @@ const EXPORTS = {
   AWS_R53_ZONE_PREFIX: '/hostedzone/',
   AWS_SSL_ID:
     'arn:aws:iam::731670193630:server-certificate/clusternator-wildcard',
+  AWS_RETRY_DELAY: 1500,
+  AWS_RETRY_LIMIT: 3,
+  AWS_RETRY_MULTIPLIER: 3
 
 };
 

--- a/src/aws/common.js
+++ b/src/aws/common.js
@@ -428,7 +428,7 @@ function createTask(task, creq) {
 
 /**
  * @param {Object} elb
- * @param {Object} creq
+ * @param {{ elbId: string, ec2Info: Object }} creq
  * @returns {Q.Promise<Object>}
  */
 function registerEc2ToElb(elb, creq) {

--- a/src/aws/common.js
+++ b/src/aws/common.js
@@ -433,7 +433,7 @@ function createTask(task, creq) {
  */
 function registerEc2ToElb(elb, creq) {
   return elb.registerInstances(creq.elbId,
-    [findIdFromEc2Describe(creq.ec2Info)])
+    [findIdFromEc2Describe(creq.ec2Info)])()
     .then(() => creq);
 }
 

--- a/src/aws/deploymentManager.js
+++ b/src/aws/deploymentManager.js
@@ -71,7 +71,7 @@ function getDeploymentManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
    */
   function setGroupId(creq) {
     return securityGroup
-      .createDeployment(creq.projectId, creq.deployment)
+      .createDeployment(creq.projectId, creq.deployment)()
       .then((groupId) => {
         creq.groupId = groupId;
         return creq;
@@ -174,7 +174,7 @@ function getDeploymentManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
         // fail over
         .fail(() => undefined))
       .then(() => securityGroup
-        .destroyDeployment(projectId, deployment)
+        .destroyDeployment(projectId, deployment)()
         // fail over
         .fail(() => undefined));
   }

--- a/src/aws/deploymentManager.js
+++ b/src/aws/deploymentManager.js
@@ -52,7 +52,7 @@ function getDeploymentManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
 
   function createElb(creq) {
     return elb.createDeployment(creq.projectId, creq.deployment, creq.subnetId,
-      creq.groupId, awsConstants.AWS_SSL_ID, creq.useInternalSSL);
+      creq.groupId, awsConstants.AWS_SSL_ID, creq.useInternalSSL)();
   }
 
   function setUrl(creq) {
@@ -138,13 +138,13 @@ function getDeploymentManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
    * @returns {Request|Promise.<T>}
    */
   function destroyRoutes(projectId, deployment) {
-    return elb.describeDeployment(projectId, deployment)
+    return elb.describeDeployment(projectId, deployment)()
       .then((result) => route53
         .destroyDeploymentCNameRecord(projectId, deployment, result.dns));
   }
 
   function destroyElb(projectId, deployment) {
-    return elb.destroyDeployment(projectId, deployment)
+    return elb.destroyDeployment(projectId, deployment)()
       //fail over
       .fail((err) => util.warn(err));
   }

--- a/src/aws/ec2/ec2-tag.js
+++ b/src/aws/ec2/ec2-tag.js
@@ -21,7 +21,7 @@ module.exports = {
  * @param {AwsWrapper} aws
  * @param {string[]} resources
  * @param {Ec2Tag[]} tags
- * @returns {Promise}
+ * @returns {function(): Promise}
  * @throws {TypeError}
  */
 function tag(aws, resources, tags) {
@@ -31,10 +31,15 @@ function tag(aws, resources, tags) {
   if (!Array.isArray(tags)) {
     throw new TypeError('tag expects a tags array');
   }
-  return aws.ec2.createTags({
-    Resources: resources,
-    Tags: tags
-  });
+
+  function promiseToCreateTags() {
+    return aws.ec2.createTags({
+      Resources: resources,
+      Tags: tags
+    });
+  }
+
+  return promiseToCreateTags;
 }
 
 /**

--- a/src/aws/ec2/ec2-tag.spec.js
+++ b/src/aws/ec2/ec2-tag.spec.js
@@ -43,8 +43,8 @@ describe('AWS: EC2: Tag', () => {
       expect(() => ec2.tag(aws, 'test', [])).to.throw(TypeError);
     });
 
-    it('should call ec2.createTags', (done) => {
-      ec2.tag(aws, [], [])
+    it('should return a function that calls ec2.createTags', (done) => {
+      ec2.tag(aws, [], [])()
         .then((r) => C
           .check(done, () => expect(r).to.equal(true)), C.getFail(done));
     });

--- a/src/aws/ec2/security-groups.js
+++ b/src/aws/ec2/security-groups.js
@@ -57,7 +57,7 @@ function bindAws(aws) {
  * @param {AwsWrapper} aws
  * @param {string} groupId
  * @param {SgIpPermissions[]} ipPermissions
- * @returns {Q.Promise}
+ * @returns {function(): Promise}
  * @throws {TypeError}
  */
 function authorizeIngress(aws, groupId, ipPermissions) {
@@ -65,42 +65,57 @@ function authorizeIngress(aws, groupId, ipPermissions) {
     throw new TypeError('authorizeIngress requires array of IP permissions');
   }
 
-  return aws.ec2.authorizeSecurityGroupIngress({
-    GroupId: groupId,
-    IpPermissions: ipPermissions
-  });
+  function promiseToAuthorizeIngress() {
+    return aws.ec2.authorizeSecurityGroupIngress({
+      GroupId: groupId,
+      IpPermissions: ipPermissions
+    });
+
+  }
+  return promiseToAuthorizeIngress;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} groupId
  * @param {SgIpPermissions[]} ipPermissions
- * @returns {Q.Promise}
+ * @returns {function(): Promise}
  * @throws {TypeError}
  */
 function authorizeEgress(aws, groupId, ipPermissions) {
   if (!Array.isArray(ipPermissions)) {
     throw new TypeError('authorizeEgress requires array of IP permissions');
   }
-  return aws.ec2.authorizeSecurityGroupEgress({
-    GroupId: groupId,
-    IpPermissions: ipPermissions
-  });
+
+  function promiseToAuthorizeEgress() {
+    return aws.ec2.authorizeSecurityGroupEgress({
+      GroupId: groupId,
+      IpPermissions: ipPermissions
+    });
+  }
+
+  return promiseToAuthorizeEgress;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} name
  * @param {string} description
- * @returns {Q.Promise<string>}
+ * @returns {function(): Promise<string>}
  */
 function create(aws, name, description) {
-  return aws.ec2
-    .createSecurityGroup({
-      GroupName: name,
-      Description: description,
-      VpcId: aws.vpcId })
-    .then((result) => result.GroupId);
+
+  function promiseToCreate() {
+    return aws.ec2
+      .createSecurityGroup({
+        GroupName: name,
+        Description: description,
+        VpcId: aws.vpcId
+      })
+      .then((result) => result.GroupId);
+  }
+
+  return promiseToCreate;
 }
 
 /**
@@ -132,20 +147,24 @@ function createPrName(projectId, pr) {
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} pr
- * @returns {Q.Promise<string>}
+ * @returns {function(): Promise<string>}
  */
 function createPr(aws, projectId, pr) {
   const id = createPrName(projectId, pr);
 
-  return listPr(aws, projectId, pr)
-    .then((r) => r.length ? r[0] : create(
-      aws, id, `Created by The Clusternator For ${projectId} PR #${pr}`)
-      .then((id) => tag
-        .tag(aws, [id], getPrTags(projectId, pr))()
-        .then(authorizeIngress(aws, id, [
-          ipPerms.create(-1, 1, 65534, [ipRange.create('0.0.0.0/0')])
-        ]))
-        .then(() => id)));
+  function promiseToCreatePr() {
+    return listPr(aws, projectId, pr)()
+      .then((r) => r.length ? r[0] : create(
+        aws, id, `Created by The Clusternator For ${projectId} PR #${pr}`)()
+        .then((id) => tag
+          .tag(aws, [id], getPrTags(projectId, pr))()
+          .then(() => authorizeIngress(aws, id, [
+            ipPerms.create(-1, 1, 65534, [ipRange.create('0.0.0.0/0')])
+          ])())
+          .then(() => id)));
+  }
+
+  return promiseToCreatePr;
 }
 
 /**
@@ -177,109 +196,149 @@ function createDeploymentName(projectId, deployment) {
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} deployment
- * @returns {Q.Promise<string>}
+ * @returns {function(): Promise<string>}
  */
 function createDeployment(aws, projectId, deployment) {
   const id = createDeploymentName(projectId, deployment);
-  return listDeployment(aws, projectId, deployment)
-    .then((r) => r.length ? r[0] : create(
-      aws, id, `Created by The Clusternator For ${projectId} deployment ` +
-      deployment)
-      .then((id) => tag
-        .tag(aws, [id], getDeploymentTags(projectId, deployment))()
-        .then(authorizeIngress(aws, id, [
-          ipPerms.create(-1, 1, 65534, [ipRange.create('0.0.0.0/0')])
-        ]))
-        .then(() => id)));
+
+  function promiseToCreateDeployment() {
+    return listDeployment(aws, projectId, deployment)()
+      .then((r) => r.length ? r[0] : create(
+        aws, id, `Created by The Clusternator For ${projectId} deployment ` +
+        deployment)()
+        .then((id) => tag
+          .tag(aws, [id], getDeploymentTags(projectId, deployment))()
+          .then(() => authorizeIngress(aws, id, [
+            ipPerms.create(-1, 1, 65534, [ipRange.create('0.0.0.0/0')])
+          ])())
+          .then(() => id)));
+  }
+
+  return promiseToCreateDeployment;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} groupId
- * @returns {Promise.<string>}
+ * @returns {function(): Promise.<string>}
  */
 function destroy(aws, groupId) {
-  return aws.ec2.deleteSecurityGroup({
-    GroupId: groupId
-  }).then(() => 'deleted');
+
+  function promiseToDestroy() {
+    return aws.ec2.deleteSecurityGroup({
+      GroupId: groupId
+    }).then(() => 'deleted');
+  }
+
+  return promiseToDestroy;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} deployment
- * @returns {Promise.<string>}
+ * @returns {function(): Promise.<string>}
  */
 function destroyDeployment(aws, projectId, deployment) {
-  return listDeployment(aws, projectId, deployment)
-    .then((r) => r.length ? destroy(aws, r[0]) : 'already deleted');
+
+  function promiseToDestroyDeployment() {
+    return listDeployment(aws, projectId, deployment)()
+      .then((r) => r.length ? destroy(aws, r[0]) : 'already deleted');
+  }
+
+  return promiseToDestroyDeployment;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} pr
- * @returns {Promise.<string>}
+ * @returns {function(): Promise.<string>}
  */
 function destroyPr(aws, projectId, pr) {
-  return listPr(aws, projectId, pr)
-    .then((r) => r.length ? destroy(aws, r[0]) : 'already deleted');
+
+  function promiseToDestroyPr() {
+    return listPr(aws, projectId, pr)()
+      .then((r) => r.length ? destroy(aws, r[0]) : 'already deleted');
+  }
+
+  return promiseToDestroyPr;
 }
 
 /**
  * @param {AwsWrapper} aws
- * @returns {Promise}
+ * @returns {function(): Promise}
  */
 function describe(aws) {
-  return aws.ec2.describeSecurityGroups({
-    Filters: [
-      filter.createVpc(aws.vpcId),
-      filter.createClusternator()
-    ]
-  });
+
+  function promiseToDescribe() {
+    return aws.ec2.describeSecurityGroups({
+      Filters: [
+        filter.createVpc(aws.vpcId),
+        filter.createClusternator()
+      ]
+    });
+  }
+
+  return promiseToDescribe;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
- * @returns {Q.Promise}
+ * @returns {function(): Promise}
  */
 function describeProject(aws, projectId) {
-  return aws.ec2.describeSecurityGroups({
-    Filters: [
-      filter.createVpc(aws.vpcId),
-      filter.createClusternator(),
-      filter.createTag(constants.PROJECT_TAG, projectId)
-    ]
-  });
+
+  function promiseToDescribeProject() {
+    return aws.ec2.describeSecurityGroups({
+      Filters: [
+        filter.createVpc(aws.vpcId),
+        filter.createClusternator(),
+        filter.createTag(constants.PROJECT_TAG, projectId)
+      ]
+    });
+  }
+
+  return promiseToDescribeProject;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} pr
- * @returns {Q.Promise}
+ * @returns {function(): Promise}
  */
 function describePr(aws, projectId, pr) {
-  return aws.ec2.describeSecurityGroups({
-    Filters: [
-      filter.createSgName(createPrName(projectId, pr))
-    ]
-  });
+
+  function promiseToDescribePr() {
+    return aws.ec2.describeSecurityGroups({
+      Filters: [
+        filter.createSgName(createPrName(projectId, pr))
+      ]
+    });
+  }
+
+  return promiseToDescribePr;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} deployment
- * @returns {Q.Promise}
+ * @returns {function(): Promise}
  */
 function describeDeployment(aws, projectId, deployment) {
-  return aws.ec2.describeSecurityGroups({
-    Filters: [
-      filter.createSgName(createDeploymentName(projectId, deployment))
-    ]
-  });
+
+  function promiseToDescribeDescribeDeployment() {
+    return aws.ec2.describeSecurityGroups({
+      Filters: [
+        filter.createSgName(createDeploymentName(projectId, deployment))
+      ]
+    });
+  }
+
+  return promiseToDescribeDescribeDeployment;
 }
 
 /**
@@ -300,41 +359,61 @@ function mapDescribeToGroupIds(descriptions) {
 
 /**
  * @param {AwsWrapper} aws
- * @returns {Q.Promise<string[]>}
+ * @returns {function(): Promise<string[]>}
  */
 function list(aws) {
-  return describe(aws)
-    .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+
+  function promiseToList() {
+    return describe(aws)()
+      .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+  }
+
+  return promiseToList;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
- * @returns {Q.Promise<string[]>}
+ * @returns {function(): Promise<string[]>}
  */
 function listProject(aws, projectId) {
-  return describeProject(aws, projectId)
-    .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+
+  function promiseToListProject() {
+    return describeProject(aws, projectId)()
+      .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+  }
+
+  return promiseToListProject;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} pr
- * @returns {Q.Promise<string[]>}
+ * @returns {function(): Promise<string[]>}
  */
 function listPr(aws, projectId, pr) {
-  return describePr(aws, projectId, pr)
-    .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+
+  function promiseToListPr() {
+    return describePr(aws, projectId, pr)()
+      .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+  }
+
+  return promiseToListPr;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} projectId
  * @param {string} deployment
- * @returns {Q.Promise<string[]>}
+ * @returns {function(): Promise<string[]>}
  */
 function listDeployment(aws, projectId, deployment) {
-  return describeDeployment(aws, projectId, deployment)
-    .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+
+  function promiseToListDeployment() {
+    return describeDeployment(aws, projectId, deployment)()
+      .then((result) => mapDescribeToGroupIds(result.SecurityGroups));
+  }
+
+  return promiseToListDeployment;
 }

--- a/src/aws/ec2/security-groups.js
+++ b/src/aws/ec2/security-groups.js
@@ -294,10 +294,17 @@ function destroyDeployment(aws, projectId, deployment) {
 
   function promiseToDestroyDeployment() {
     return listDeployment(aws, projectId, deployment)()
-      .then((r) => r.length ? destroy(aws, r[0]) : 'already deleted');
+      .then((r) => r.length ? destroy(aws, r[0])() : 'already deleted');
   }
 
-  return promiseToDestroyDeployment;
+  return util.makeRetryPromiseFunction(
+    promiseToDestroyDeployment, 
+    awsConstants.AWS_RETRY_LIMIT, 
+    awsConstants.AWS_RETRY_DELAY, 
+    awsConstants.AWS_RETRY_MULTIPLIER, 
+    null, 
+    'Security Group PR Destroy'
+  );
 }
 
 /**
@@ -310,10 +317,17 @@ function destroyPr(aws, projectId, pr) {
 
   function promiseToDestroyPr() {
     return listPr(aws, projectId, pr)()
-      .then((r) => r.length ? destroy(aws, r[0]) : 'already deleted');
+      .then((r) => r.length ? destroy(aws, r[0])() : 'already deleted');
   }
 
-  return promiseToDestroyPr;
+  return util.makeRetryPromiseFunction(
+    promiseToDestroyPr,
+    awsConstants.AWS_RETRY_LIMIT,
+    awsConstants.AWS_RETRY_DELAY,
+    awsConstants.AWS_RETRY_MULTIPLIER,
+    null,
+    'Security Group PR Destroy'
+  );
 }
 
 /**

--- a/src/aws/ec2/security-groups.js
+++ b/src/aws/ec2/security-groups.js
@@ -141,7 +141,7 @@ function createPr(aws, projectId, pr) {
     .then((r) => r.length ? r[0] : create(
       aws, id, `Created by The Clusternator For ${projectId} PR #${pr}`)
       .then((id) => tag
-        .tag(aws, [id], getPrTags(projectId, pr))
+        .tag(aws, [id], getPrTags(projectId, pr))()
         .then(authorizeIngress(aws, id, [
           ipPerms.create(-1, 1, 65534, [ipRange.create('0.0.0.0/0')])
         ]))
@@ -186,7 +186,7 @@ function createDeployment(aws, projectId, deployment) {
       aws, id, `Created by The Clusternator For ${projectId} deployment ` +
       deployment)
       .then((id) => tag
-        .tag(aws, [id], getDeploymentTags(projectId, deployment))
+        .tag(aws, [id], getDeploymentTags(projectId, deployment))()
         .then(authorizeIngress(aws, id, [
           ipPerms.create(-1, 1, 65534, [ipRange.create('0.0.0.0/0')])
         ]))

--- a/src/aws/ec2/security-groups.spec.js
+++ b/src/aws/ec2/security-groups.spec.js
@@ -225,4 +225,19 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
+
+  describe('tagPrOrDeployment function', () => {
+    it('should return a function', () => {
+      expect(typeof sg.helpers
+        .tagPrOrDeployment(aws, 'project', 'id', 'prOrDeployment', () => {}))
+        .to.equal('function');
+    });
+    
+    it('should return a function that returns a promise', () => {
+      expect(typeof sg.helpers
+        .tagPrOrDeployment(
+          aws, 'project', 'id', 'prOrDeployment', () => [])().then)
+        .to.equal('function');
+    });
+  });
 });

--- a/src/aws/ec2/security-groups.spec.js
+++ b/src/aws/ec2/security-groups.spec.js
@@ -34,7 +34,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
     });
     
     it('should call ec2.authorozieSecurityGroupIngress', (done) => {
-      sg.authorizeIngress(aws, 't', [])
+      sg.authorizeIngress(aws, 't', [])()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -46,7 +46,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
     });
 
     it('should call ec2.authorozieSecurityGroupEgress', (done) => {
-      sg.authorizeEgress(aws, 't', [])
+      sg.authorizeEgress(aws, 't', [])()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -54,7 +54,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('create function', () => {
     it('should call ec2.createSecurityGroup', (done) => {
-      sg.create(aws, 'group', 'desc')
+      sg.create(aws, 'group', 'desc')()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -62,14 +62,14 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('createPr function', () => {
     it('should resolve existing security groups first', (done) => {
-      sg.createPr(aws, 'project', '23')
+      sg.createPr(aws, 'project', '23')()
         .then((r) => C
           .check(done, () => expect(r).to.equal('groupId')), C.getFail(done));
     });
 
     it('should create new groups if they don\'t exist', (done) => {
       aws.ec2.describeSecurityGroups = () => Q.resolve({ SecurityGroups: [] });
-      sg.createPr(aws, 'project', '23')
+      sg.createPr(aws, 'project', '23')()
         .then((r) => C
           .check(done, () => expect(r).to.equal('groupId-sg')),
           C.getFail(done));
@@ -78,14 +78,14 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('createDeployment function', () => {
     it('should resolve existing security groups first', (done) => {
-      sg.createDeployment(aws, 'project', 'betta')
+      sg.createDeployment(aws, 'project', 'betta')()
         .then((r) => C
           .check(done, () => expect(r).to.equal('groupId')), C.getFail(done));
     });
 
     it('should create new groups if they don\'t exist', (done) => {
       aws.ec2.describeSecurityGroups = () => Q.resolve({ SecurityGroups: [] });
-      sg.createDeployment(aws, 'project', 'beta')
+      sg.createDeployment(aws, 'project', 'beta')()
         .then((r) => C
           .check(done, () => expect(r).to.equal('groupId-sg')),
           C.getFail(done));
@@ -94,7 +94,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('destroy function', () => {
     it('should call ec2.deleteSecurityGroup', (done) => {
-      sg.destroy(aws, 'group')
+      sg.destroy(aws, 'group')()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -103,7 +103,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
   describe('destroyPr function', () => {
     it('should call ec2.deleteSecurityGroup if the deployment exists',
       (done) => {
-        sg.destroyPr(aws, 'projectId', 'pr')
+        sg.destroyPr(aws, 'projectId', 'pr')()
           .then((r) => C
             .check(done, () => expect(r).to.be.ok), C.getFail(done));
       });
@@ -111,7 +111,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
     it('should not call ec2.deleteSecurityGroup if the deployment is already ' +
       'deleted', (done) => {
         aws.ec2.describeSecurityGroups = () => Q.resolve({ SecurityGroups: []});
-        sg.destroyPr(aws, 'projectId', 'pr')
+        sg.destroyPr(aws, 'projectId', 'pr')()
           .then((r) => C
             .check(done, () => expect(r).to.be.ok), C.getFail(done));
       });
@@ -120,7 +120,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
   describe('destroyDeployment function', () => {
     it('should call ec2.deleteSecurityGroup if the deployment exists',
       (done) => {
-        sg.destroyDeployment(aws, 'projectId', 'master')
+        sg.destroyDeployment(aws, 'projectId', 'master')()
           .then((r) => C
             .check(done, () => expect(r).to.be.ok), C.getFail(done));
       });
@@ -128,7 +128,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
     it('should not call ec2.deleteSecurityGroup if the deployment is already ' +
       'deleted', (done) => {
       aws.ec2.describeSecurityGroups = () => Q.resolve({ SecurityGroups: []});
-      sg.destroyDeployment(aws, 'projectId', 'beta')
+      sg.destroyDeployment(aws, 'projectId', 'beta')()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -137,7 +137,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('describe function', () => {
     it('should call ec2.describeSecurityGroups', (done) => {
-      sg.describe(aws)
+      sg.describe(aws)()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -145,7 +145,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('describe project function', () => {
     it('should call ec2.describeSecurityGroups', (done) => {
-      sg.describeProject(aws, 'id')
+      sg.describeProject(aws, 'id')()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -153,7 +153,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('describe pr function', () => {
     it('should call ec2.describeSecurityGroups', (done) => {
-      sg.describePr(aws, 'id', 'pr #')
+      sg.describePr(aws, 'id', 'pr #')()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -161,7 +161,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('describe deployment function', () => {
     it('should call ec2.describeSecurityGroups', (done) => {
-      sg.describeDeployment(aws, 'id', 'master')
+      sg.describeDeployment(aws, 'id', 'master')()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
@@ -169,7 +169,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('list function', () => {
     it('resolve an array of strings', (done) => {
-      sg.list(aws)
+      sg.list(aws)()
         .then((r) => C
           .check(done, () => expect(typeof r[0]).to.equal('string')),
           C.getFail(done));
@@ -178,7 +178,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('list project function', () => {
     it('resolve an array of strings', (done) => {
-      sg.listProject(aws, 'id')
+      sg.listProject(aws, 'id')()
         .then((r) => C
           .check(done, () => expect(typeof r[0]).to.equal('string')),
           C.getFail(done));
@@ -187,7 +187,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('list pr function', () => {
     it('resolve an array of strings', (done) => {
-      sg.listPr(aws, 'id', 'pr #')
+      sg.listPr(aws, 'id', 'pr #')()
         .then((r) => C
           .check(done, () => expect(typeof r[0]).to.equal('string')),
           C.getFail(done));
@@ -196,7 +196,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
 
   describe('list deployment function', () => {
     it('resolve an array of strings', (done) => {
-      sg.listDeployment(aws, 'id', 'master')
+      sg.listDeployment(aws, 'id', 'master')()
         .then((r) => C
           .check(done, () => expect(typeof r[0]).to.equal('string')),
           C.getFail(done));
@@ -220,7 +220,7 @@ describe('AWS: EC2: Security Group IP Permissions', () => {
   describe('bindAws function', () => {
     it('should return a copy of the api bound with an aws object', (done) => {
       const s = sg.bindAws(aws);
-      s.list()
+      s.list()()
         .then((r) => C
           .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });

--- a/src/aws/elb/elb-tag.js
+++ b/src/aws/elb/elb-tag.js
@@ -10,6 +10,8 @@ module.exports = {
 };
 
 /**
+ * @todo this is identical to the ec2 tag lets generalize these at some point
+ * 
  * @param {string} key
  * @param {string} value
  * @constructor

--- a/src/aws/elb/elb.js
+++ b/src/aws/elb/elb.js
@@ -345,7 +345,7 @@ function mapInstances(instances) {
  * @param {AwsWrapper} aws
  * @param {string} loadBalancerId
  * @param {string[]} instances
- * @returns {Promise}
+ * @returns {function(): Promise}
  * @throws {TypeError}
  */
 function registerInstances(aws, loadBalancerId, instances) {
@@ -355,17 +355,20 @@ function registerInstances(aws, loadBalancerId, instances) {
   
   const mappedInstances = mapInstances(instances);
   
-  return aws.elb.registerInstancesWithLoadBalancer({
-    Instances: mappedInstances,
-    LoadBalancerName: loadBalancerId
-  });
+  function promiseToRegister() {
+    return aws.elb.registerInstancesWithLoadBalancer({
+      Instances: mappedInstances,
+      LoadBalancerName: loadBalancerId
+    });
+  }
+  return promiseToRegister;
 }
 
 /**
  * @param {AwsWrapper} aws
  * @param {string} loadBalancerId
  * @param {string[]} instances
- * @returns {Promise}
+ * @returns {function(): Promise}
  * @throws {TypeError}
  */
 function deRegisterInstances(aws, loadBalancerId, instances) {
@@ -375,8 +378,11 @@ function deRegisterInstances(aws, loadBalancerId, instances) {
   
   const mappedInstances = mapInstances(instances);
   
-  return aws.elb.deregisterInstancesFromLoadBalancer({
-    Instances: mappedInstances,
-    LoadBalancerName: loadBalancerId
-  });
+  function promiseToDeRegister() {
+    return aws.elb.deregisterInstancesFromLoadBalancer({
+      Instances: mappedInstances,
+      LoadBalancerName: loadBalancerId
+    });
+  }
+  return promiseToDeRegister;
 }

--- a/src/aws/elb/elb.spec.js
+++ b/src/aws/elb/elb.spec.js
@@ -27,13 +27,16 @@ describe('AWS: ELB', () => {
   beforeEach(initData);
 
   describe('configureHealthCheckFunction', () => {
+    it('should return a function', () => {
+      expect(typeof elb.configureHealthCheck(aws)).to.equal('function');
+    });
     it('should resolve if ec2 call resolves', (done) => {
-      elb.configureHealthCheck(aws)
+      elb.configureHealthCheck(aws)()
         .then((r) => C.check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
     it('should reject if ec2 call rejects', (done) => {
       aws.elb.configureHealthCheck = () => Q.reject(new Error('test'));
-      elb.configureHealthCheck(aws)
+      elb.configureHealthCheck(aws)()
         .then(C.getFail(done), (e) => C
           .check(done, () => expect(e instanceof Error).to.be.ok));
     });
@@ -71,7 +74,7 @@ describe('AWS: ELB', () => {
 
   describe('create function', () => {
     it('should resolve a promise', (done) => {
-      elb.create(aws).then((r) => C
+      elb.create(aws)().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -86,7 +89,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.createDeployment(aws, 'test', 'master').then((r) => C
+      elb.createDeployment(aws, 'test', 'master')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -101,7 +104,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.createPr(aws, 'test', '76').then((r) => C
+      elb.createPr(aws, 'test', '76')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -112,7 +115,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.destroy(aws, 'test').then((r) => C
+      elb.destroy(aws, 'test')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -127,7 +130,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.destroyPr(aws, 'test', '1').then((r) => C
+      elb.destroyPr(aws, 'test', '1')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -142,28 +145,36 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.destroyDeployment(aws, 'test', 'master').then((r) => C
+      elb.destroyDeployment(aws, 'test', 'master')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
 
   describe('describeAll function', () => {
+    it('should return a function', () => {
+      expect(typeof elb.describeAll(aws)).to.equal('function');
+    });
+    
     it('should resolve a promise', (done) => {
-      elb.describeAll(aws).then((r) => C
+      elb.describeAll(aws)().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
 
   describe('describeById function', () => {
+    it('should return a function', () => {
+      expect(typeof elb.helpers.describeById(aws)).to.equal('function');
+    });
+    
     it('should resolve a promise if it has a result set', (done) => {
-      elb.helpers.describeById(aws).then((r) => C
+      elb.helpers.describeById(aws)().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
 
     it('should reject a promise if it has no result set', (done) => {
       aws.elb.describeLoadBalancers = () => Q.resolve({
         LoadBalancerDescriptions: [] });
-      elb.helpers.describeById(aws).then(C.getFail(done), (e) => C
+      elb.helpers.describeById(aws)().then(C.getFail(done), (e) => C
         .check(done, () => expect(e instanceof Error).to.be.ok));
     });
   });
@@ -178,7 +189,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.describeDeployment(aws, 'test', 'master').then((r) => C
+      elb.describeDeployment(aws, 'test', 'master')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -193,7 +204,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve a promise', (done) => {
-      elb.describePr(aws, 'test', '1').then((r) => C
+      elb.describePr(aws, 'test', '1')().then((r) => C
         .check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });

--- a/src/aws/elb/elb.spec.js
+++ b/src/aws/elb/elb.spec.js
@@ -16,7 +16,8 @@ function initData() {
     describeLoadBalancers: () => Q.resolve({ LoadBalancerDescriptions: [
       { DNSName: 'test' }
     ]}),
-    registerInstancesWithLoadBalancer: () => Q.resolve(true)
+    registerInstancesWithLoadBalancer: () => Q.resolve(true),
+    deregisterInstancesFromLoadBalancer: () => Q.resolve(true)
   };
 }
 
@@ -201,9 +202,28 @@ describe('AWS: ELB', () => {
     it('should throw without an instances array', () => {
       expect(() => elb.registerInstances(aws, 'test', 5)).to.throw(TypeError);
     });
+    
+    it('should throw without an instance name', () => {
+      expect(() => elb.registerInstances(aws)).to.throw(TypeError);
+    });
 
     it('should resolve if its ec2 call resolves', (done) => {
       elb.registerInstances(aws, 'test', [{ InstanceId: 'test' }])
+        .then((r) => C.check(done, () => expect(r).to.be.ok), C.getFail(done));
+    });
+  });
+  
+  describe('deRegisterInstances function', () => {
+    it('should throw without an instances array', () => {
+      expect(() => elb.deRegisterInstances(aws, 'test', 5)).to.throw(TypeError);
+    });
+
+    it('should throw without an instance name', () => {
+      expect(() => elb.deRegisterInstances(aws)).to.throw(TypeError);
+    });
+
+    it('should resolve if its ec2 call resolves', (done) => {
+      elb.deRegisterInstances(aws, 'test', [{ InstanceId: 'test' }])
         .then((r) => C.check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });

--- a/src/aws/elb/elb.spec.js
+++ b/src/aws/elb/elb.spec.js
@@ -219,7 +219,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve if its ec2 call resolves', (done) => {
-      elb.registerInstances(aws, 'test', [{ InstanceId: 'test' }])
+      elb.registerInstances(aws, 'test', [{ InstanceId: 'test' }])()
         .then((r) => C.check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });
@@ -234,7 +234,7 @@ describe('AWS: ELB', () => {
     });
 
     it('should resolve if its ec2 call resolves', (done) => {
-      elb.deRegisterInstances(aws, 'test', [{ InstanceId: 'test' }])
+      elb.deRegisterInstances(aws, 'test', [{ InstanceId: 'test' }])()
         .then((r) => C.check(done, () => expect(r).to.be.ok), C.getFail(done));
     });
   });

--- a/src/aws/prManager.js
+++ b/src/aws/prManager.js
@@ -72,7 +72,7 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
    */
   function setGroupId(creq) {
     return securityGroup
-      .createPr(creq.projectId, creq.pr)
+      .createPr(creq.projectId, creq.pr)()
       .then((groupId) => {
         creq.groupId = groupId;
         return creq;
@@ -177,7 +177,7 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
         .destroy(clusterName)
         .fail(() => undefined))
       .then(() => securityGroup
-        .destroyPr(projectId, pr));
+        .destroyPr(projectId, pr)());
   }
 
   return {

--- a/src/aws/prManager.js
+++ b/src/aws/prManager.js
@@ -54,7 +54,7 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
 
   function createElb(creq) {
     return elb.createPr(creq.projectId, creq.pr, creq.subnetId,
-      creq.groupId, awsConstants.AWS_SSL_ID);
+      creq.groupId, awsConstants.AWS_SSL_ID)();
   }
 
   function setUrl(creq) {
@@ -137,7 +137,7 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
    * @returns {Request|Promise.<T>}
    */
   function destroyRoutes(projectId, pr) {
-    return elb.describePr(projectId, pr)
+    return elb.describePr(projectId, pr)()
       .then((result) => route53
         .destroyPRCNameRecord(projectId, pr, result.dns));
   }
@@ -148,7 +148,7 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
    * @returns {Q.Promise}
    */
   function destroyElb(projectId, pr) {
-    return elb.destroyPr(projectId, pr)
+    return elb.destroyPr(projectId, pr)()
       //fail over
       .fail((err) => util.warn(err));
   }

--- a/src/aws/prManager.js
+++ b/src/aws/prManager.js
@@ -110,6 +110,71 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
   }
 
   /**
+   * @param {{ elbId: string, instanceIds: Array.<string>, pr: string, 
+   name: string, projectId: string }} creq
+   * @returns {Promise.<Promise.<Object>>}
+   */
+  function updateDestroy(creq) {
+    return elb.deRegisterInstances(creq.elbId, creq.instanceIds)()
+      .then(() =>
+        destroyEc2(creq.projectId, creq.pr, creq.name)
+          .then((r) => task
+            .destroy(creq.name)
+            .fail((err) => {
+              util.info(`PR Problem Destroying Task: ${err.message}`);
+              return r;
+            }))
+          /**
+           * @todo we don't have to destroy this cluster, there is a better way,
+           * this is a temporary solution.  @rafkhan knows the cluster update 
+           * story best and also knows its issues at the moment
+           */
+          .then(() => cluster
+            .destroy(creq.name)
+            .fail(() => undefined)));
+  }
+
+  /**
+   * @param {string} projectId
+   * @param {string} pr
+   * @param {Object} appDef
+   * @param {string[]|string} sshKeys
+   * @param {string} elbId
+   * @param {string[]} instanceIds
+   * @returns {Promise}
+   */
+  function update(projectId, pr, appDef, sshKeys, elbId, instanceIds) {
+    const creq = {
+      appDef,
+      elbId,
+      sshPath: sshKeys || '',
+      instanceIds,
+      name: rid.generateRID({ pid: projectId, pr }),
+      pr: pr + '',
+      projectId
+    };
+    
+    return updateDestroy(creq)
+      .then(() => common
+      .setSubnet(subnet, creq)
+      .then(() => Q
+        .all([
+          setGroupId(creq),
+          cluster.create(creq.name) 
+        ])
+        .then(() => creq))
+      .then(() => createEc2(creq)
+        .then((results) => creq.ec2Info = results))
+      .then(() => common.createTask(task, creq))
+      .then(() => common.registerEc2ToElb(elb, creq))
+      .then(() => { 
+        creq.url = route53.generatePRDomain(projectId, pr); 
+        return creq;
+      })
+      .then((creq) => common.qualifyUrl(Config(), creq.url)));
+  }
+
+  /**
    * @param {string} projectId
    * @param {string} pr
    * @param {string} clusterName
@@ -181,8 +246,9 @@ function getPRManager(ec2, ecs, r53, awsElb, vpcId, zoneId) {
   }
 
   return {
-    create: create,
-    destroy: destroy
+    create,
+    destroy,
+    update
   };
 }
 

--- a/src/aws/route53Manager.js
+++ b/src/aws/route53Manager.js
@@ -380,6 +380,8 @@ return {
   destroyDeploymentARecord,
   destroyDeploymentCNameRecord,
   findId,
+  generatePRDomain: rid.generatePRSubdomain,
+  generateDeploymentDomain,
   helpers: {
     createRecordParams,
     createChange,

--- a/src/util.spec.js
+++ b/src/util.spec.js
@@ -144,10 +144,10 @@ describe('utility functions', () => {
     });
   });
 
-  describe('makeRetryPromise function', () => {
+  describe('makeRetryPromiseFunction function', () => {
     it('should resolve resolving promises', (done) => {
       const d = Q.defer();
-      util.makeRetryPromise(() => d.promise)
+      util.makeRetryPromiseFunction(() => d.promise)()
         .then((r) => C.check(done, () => expect(r).to.equal(true)),
           C.getFail(done));
       d.resolve(true);
@@ -169,7 +169,7 @@ describe('utility functions', () => {
         return d.promise;
       };
       // test
-      util.makeRetryPromise(pReturn, 2)
+      util.makeRetryPromiseFunction(pReturn, 2)()
         .then((r) => C.check(done, () => expect(r).to.equal(true)),
           C.getFail(done));
     });
@@ -190,7 +190,7 @@ describe('utility functions', () => {
         return d.promise;
       };
       // test
-      util.makeRetryPromise(pReturn, 2)
+      util.makeRetryPromiseFunction(pReturn, 2)()
         .then(C.getFail(done), (err) => C
           .check(done, () => expect(err instanceof Error).to.be.ok));
     });
@@ -211,7 +211,7 @@ describe('utility functions', () => {
         return d.promise;
       };
       // test
-      util.makeRetryPromise(pReturn, 2, 100, 1, () => true, 'word')
+      util.makeRetryPromiseFunction(pReturn, 2, 100, 1, () => true, 'word')()
         .then(C.getFail(done), (err) => C
           .check(done, () => expect(err instanceof Error).to.be.ok));
     });


### PR DESCRIPTION
This is going to be one of at least two stability updates that address some of the AWS issues we've been having.  I'm breaking up the PR's because this is working _now_ where as further stability updates, including ZDU updates will benefit from more extensive testing, and some refactoring. 

This is connected to #296  and connected to #244 but closes neither issue.

The reason this is worth a PR is that it _slightly_ speeds up rebuilds/redploys and because it solves DNS issues on rebuild/redeploy.

- Security groups retry failed tagging of PRs/Deployments
- Security groups retry failed deletions
- Updating PR's and deployments no longer tear down load balancers
- Updating PR's and deployments no longer tear down route53 DNS
- ELB section of AWS code now returns promise returning functions instead of promises