### PR TITLE
[WIP - DON'T MERGE] Fix/cli cleanup

### DIFF
--- a/bin-src/clusternator-cli.js
+++ b/bin-src/clusternator-cli.js
@@ -14,5 +14,5 @@ const API = USER ?
 
 const yargs = require('yargs');
 
-require(`../lib/api/${API}/cli/cli-api`)(yargs);
-
+const cli = require(`../lib/api/${API}/cli/cli-api`);
+cli.configure(yargs);

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
     "staging": "NODE_ENV=staging; node ./server-init.js",
     "start": "node ./server-init.js",
     "test": "gulp test-unit",
-    "watch": "gulp watch"
+    "watch": "gulp watch",
+    "release": "git commit -am $npm_package_version && git tag $npm_package_version && git push && npm publish && git push --tags"
   },
   "homepage": "http://the-clusternator.rangle.io",
   "repository": {

--- a/src/api/0.1/cli/cli-api.js
+++ b/src/api/0.1/cli/cli-api.js
@@ -1,15 +1,16 @@
 'use strict';
+
 /**
- * This is the primary interface to the {@link module:clusternatorCli} stub
+ * This is the primary interface to the {@link module:clusternatorCli}.
  *
- * This module uses yargs to communicate with the user/CLI and has no utility
- * outside of being the place to configure the CLI arguments.
+ * This module is responsible for parsing arguments and handling errors only.
+ * Any actual logic is delegated to internal modules.
  *
  * @module api/'0.1'/cli
  */
-
 const API = '0.1';
 
+const R = require('ramda');
 const path = require('path');
 
 const cmn = require('../common');
@@ -30,55 +31,161 @@ const dockerFs = require('../project-fs/docker');
 const deploymentsFs = require('../project-fs/deployments');
 const gitHooks = require('../project-fs/git-hooks');
 
-const getPackage = () => require('../../../../package.json');
+const pkg = require('../../../../package.json');
 
+module.exports = {
+  configure: function(yargs) {
+    const applyCommands = R.pipe.apply(null, R.values(this.commands));
+    applyCommands(yargs);
+    util.cliLogger(yargs);
 
-module.exports = (yargs) => {
+    yargs
+      .usage('Usage: $0 <command> [opts]')
+      .completion('completion', 'Generate bash completions')
+      .version(() => `Package: ${pkg.version} API: ${API}`)
+      .help('h')
+      .alias('h', 'help');
+  },
 
-  util.cliLogger(yargs);
+  // Exposed for unit testing.
+  commands: {
+    bootstrap,
+    init,
+    generateDeployment,
+    generateSshKey,
+    generatePass,
+    gitHookInstall,
+    gitHookRemove,
+    config,
+    projectCommands,
+    createUser,
+    login,
+    passwd,
+    certUpload,
+    certDelete,
+    certList,
+    serve,
+    listAuthorities,
+    listProjects,
+    describeServices,
+    build,
+    deploy,
+    stop,
+    update,
+    makePrivate,
+    readPrivate,
+    privateChecksum,
+    privateDiff,
+    log,
+    logEcs,
+    ssh
+  }
+};
 
-  yargs.usage('Usage: $0 <command> [opts]');
-
-  const argv = yargs
-    .completion('completion', 'Generate bash completions')
-    .command('bootstrap', 'Bootstraps an AWS environment so that projects ' +
-      'can be launched into it', () => util.info('Bootstrap environment'))
-    .command('init', 'Initializes a `.clusternator` file in the project ' +
+function init(yargs) {
+  return yargs.command(
+    'init',
+    'Initializes a `.clusternator` file in the project ' +
       'repo, and provisions AWS networking resources.  Requires AWS ' +
-      'credentials', (y) => {
+      'credentials',
+    (y) => {
       y.demand('o')
         .alias('o', 'offline')
         .default('o', false)
         .describe('o', 'offline only, makes "clusternator.json" but does ' +
           '*not* check the cloud infrastructure');
 
-      project.init(y.argv.o).done();
-    })
-    .command('project', 'Project management commands (try ' +
-      'clusternator project --help)',
-      (y) => {
-        const argv = y.usage('Usage: $0 project <command> [opts]')
-          .command('create-data', 'create project db entry',
-            () => projectDb.createData().done())
-          .command('git-hub-key', 'Display GitHub key ' +
-            '(warning returns secret GitHub key)',
-            () => projectDb.getGitHub().done())
-          .command('shared-key', 'Display shared key ' +
-            '(warning returns secret shared key)',
-            () => projectDb.getShared().done())
-          .command('reset-auth-token', 'Reset authentication token',
-            () => projectDb.resetAuth().done())
-          .command('reset-git-hub-key', 'Reset GitHub key',
-            () => projectDb.resetGitHub().done())
-          .command('reset-shared-key', 'Reset shared key',
-            () => projectDb.resetShared().done())
-          .help('h')
-          .alias('h', 'help')
-          .argv;
-      })
-    .command('config', 'Configure the local clusternator user',
-      () => Config.interactiveUser().done())
-    .command('create-user', 'Create a user on the clusternator server', (y) => {
+      project.init(y.argv.o)
+        .fail(util.cliErr('Failed to initialize project.'))
+        .done();
+    });
+}
+
+function projectCommands(yargs) {
+  return yargs.command(
+    'project',
+    'Project management commands (try clusternator project --help)',
+    (y) => {
+      const applySubCommands = R.pipe(
+        project_createData,
+        project_gitHubKey,
+        project_sharedKey,
+        project_resetAuthToken,
+        project_resetGitHubKey,
+        project_resetSharedKey);
+
+      const argv = applySubCommands(y)
+        .usage('Usage: $0 project <command> [opts]')
+        .help('h')
+        .alias('h', 'help')
+        .argv;
+    });
+}
+
+function project_createData(yargs) {
+  return yargs.command(
+    'create-data',
+    'create project db entry',
+    () => projectDb.createData()
+      .fail(util.cliErr('Failed to create project data.'))
+      .done());
+}
+
+function project_gitHubKey(yargs) {
+  return yargs.command(
+    'git-hub-key',
+    'Display GitHub key (warning: returns secret GitHub key)',
+    () => projectDb.getGitHub()
+      .fail(util.cliErr('Failed to locate github key.'))
+      .done());
+}
+
+function project_sharedKey(yargs) {
+  return yargs.command(
+    'shared-key',
+    'Display shared key (warning: returns secret shared key)',
+    () => projectDb.getShared()
+      .fail(util.cliErr('Failed to locate shared key.'))
+      .done());
+}
+
+function project_resetAuthToken(yargs) {
+  return yargs.command(
+    'reset-auth-token',
+    'Reset authentication token',
+    () => projectDb.resetAuth()
+      .fail(util.cliErr('Failed to reset auth token.'))
+      .done());
+}
+
+function project_resetGitHubKey(yargs) {
+  return yargs.command(
+    'reset-git-hub-key',
+    'Reset GitHub key',
+    () => projectDb.resetGitHub()
+      .fail(util.cliErr('Failed to reset github key.'))
+      .done());
+}
+
+function project_resetSharedKey(yargs) {
+  return yargs.command('reset-shared-key', 'Reset shared key',
+    () => projectDb.resetShared()
+      .fail(util.cliErr('Failed to reset shared key.'))
+      .done());
+}
+
+function config(yargs) {
+  return yargs.command('config', 'Configure the local clusternator user',
+    () => Config.interactiveUser()
+      .fail(util.cliErr('Failed to configure local user.'))
+      .done());
+}
+
+function createUser(yargs) {
+  return yargs.command(
+    'create-user',
+    'Create a user on the clusternator server',
+    (y) => {
       y.demand('n')
         .alias('n', 'username')
         .describe('n', 'Username for the account')
@@ -97,86 +204,122 @@ module.exports = (yargs) => {
         .describe('a', 'authority of the user {number} lower numbers have ' +
           'more authority than higher number');
       user.createUser(y.argv.n, y.argv.p, y.argv.c, y.argv.a)
-        .fail((err) => console
-          .log(`Error creating user: ${err.message}`))
+        .fail(util.cliErr('Error creating user.'))
         .done();
-    })
-    .command('login', 'Login to the clusternator server',
-      (y) =>  {
-        y.demand('p')
-          .alias('p', 'password')
-          .describe('p', 'your password (be careful with shell entry like ' +
-            'this)')
-          .default('p', '')
-          .demand('u')
-          .alias('u', 'user-name')
-          .describe('u', 'user name to login with, (defaults to local config ' +
-            'if available)')
-          .default('u', '');
+    });
+}
 
-        return user.login(y.argv.u, y.argv.p).fail((err) => console
-          .log(`Error logging in: ${err.message}`))
-          .done();
-      })
-    .command('passwd', 'Change your clusternator server password',
-      (y) => {
-        y.demand('p')
-          .alias('p', 'password')
-          .describe('your password (be careful with shell entry like this)')
-          .default('p', '')
-          .demand('n')
-          .alias('n', 'new-password')
-          .describe('n', 'your NEW password (be careful with shell entry ' +
-            'like this)')
-          .default('n', '')
-          .demand('c')
-          .alias('c', 'confirm-password')
-          .describe('c', 'confirm your NEW password')
-          .default('c', '')
-          .demand('u')
-          .alias('u', 'user-name')
-          .describe('u', 'user name to login with')
-          .default('u', '');
+function login(yargs) {
+  return yargs.command('login', 'Login to the clusternator server',
+  (y) =>  {
+    y.demand('p')
+      .alias('p', 'password')
+      .describe('p', 'your password (be careful with shell entry like ' +
+        'this)')
+      .default('p', '')
+      .demand('u')
+      .alias('u', 'user-name')
+      .describe('u', 'user name to login with, (defaults to local config ' +
+        'if available)')
+      .default('u', '');
 
-        return user.changePassword(y.argv.u, y.argv.p, y.argv.n, y.argv.c)
-          .fail((err) => console
-            .log(`Error logging in: ${err.message}`))
-          .done();
-      })
-    .command('serve', 'Start a clusternator server. (typically prefer npm ' +
-      'start, or serve.sh', () =>  {
+    return user.login(y.argv.u, y.argv.p)
+      .fail(util.cliErr('Error logging in.'))
+      .done();
+  });
+}
+
+function passwd(yargs) {
+  return yargs.command('passwd', 'Change your clusternator server password',
+  (y) => {
+    y.demand('p')
+      .alias('p', 'password')
+      .describe('your password (be careful with shell entry like this)')
+      .default('p', '')
+      .demand('n')
+      .alias('n', 'new-password')
+      .describe('n', 'your NEW password (be careful with shell entry ' +
+        'like this)')
+      .default('n', '')
+      .demand('c')
+      .alias('c', 'confirm-password')
+      .describe('c', 'confirm your NEW password')
+      .default('c', '')
+      .demand('u')
+      .alias('u', 'user-name')
+      .describe('u', 'user name to login with')
+      .default('u', '');
+
+    return user.changePassword(y.argv.u, y.argv.p, y.argv.n, y.argv.c)
+      .fail(util.cliErr('Error chaning password.'))
+      .done();
+  });
+}
+
+// Promise?
+function serve(yargs) {
+  return yargs.command(
+    'serve',
+    'Start a clusternator server (i.e. \'npm start\' or \'serve.sh\'',
+    () =>  {
       const config = Config();
       return cn.startServer(config);
-    })
-    .command('list-authorities', 'List your Clusternator server\'s authorities',
-      callCommandFn(authorities.list))
+    });
+}
 
-    .command('list-projects', 'List projects with clusternator resources',
-      (y) => aws
-        .listProjects()
-        .then((projectNames) => projectNames
-          .forEach(console.log))
-        .done())
-    .command('describe-services', 'Describe project services', callCommandFn(aws
-      .describeServices))
-    .command('build', 'Local Docker Build', (y) => {
+// Promise?
+function listAuthorities(yargs) {
+  return yargs.command(
+    'list-authorities',
+    'List your Clusternator server\'s authorities',
+    callCommandFn(authorities.list));
+}
+
+// Promise?
+function listProjects(yargs) {
+  return yargs.command(
+    'list-projects',
+    'List projects with clusternator resources',
+    (y) => aws
+      .listProjects()
+      .then((projectNames) => projectNames.forEach(console.log))
+      .fail(util.cliErr('Error listing projects.'))
+      .done());
+}
+
+function describeServices(yargs) {
+  return yargs.command(
+    'describe-services',
+    'Describe project services',
+    callCommandFn(aws.describeServices));
+}
+
+function build(yargs) {
+  return yargs.command(
+    'build',
+    'Local Docker Build',
+    (y) => {
       const id = (+Date.now()).toString(16);
       const argv = demandPassphrase(y)
-          .demand('i')
-          .alias('i', 'image')
-          .describe('i', 'Name of the docker image to create')
-          .default('i', id)
-          .argv;
+        .demand('i')
+        .alias('i', 'image')
+        .describe('i', 'Name of the docker image to create')
+        .default('i', id)
+        .argv;
 
       util.info('Building Docker Image: ', argv.i);
 
-      return dockerFs
-        .build(argv.i, argv.p).fail((err) => {
-          util.error('Error building local Docker image: ', err);
-        }).done();
-    })
+      return dockerFs.build(argv.i, argv.p)
+        .fail(util.cliErr('Error building local Docker image'))
+        .done();
+    });
+}
 
-    .command('deploy', 'Makes a deployment', (y) => {
+function deploy(yargs) {
+  return yargs.command(
+    'deploy',
+    'Makes a deployment',
+    (y) => {
       y.demand('d').
       alias('d', 'deployment-name').
       describe('d', 'Requires a deployment name');
@@ -189,118 +332,221 @@ module.exports = (yargs) => {
        .alias('u', 'update')
        .describe('u', 'Forces teardown if deployment exists.');
 
-      deployments.deploy(y.argv.d, y.argv.f, y.argv.u).done();
-    })
+      deployments.deploy(y.argv.d, y.argv.f, y.argv.u)
+        .fail(util.cliErr('Error deploying.'))
+        .done();
+    });
+}
 
-    .command('stop', 'Stops a deployment, and cleans up', (y) => {
+function stop(yargs) {
+  return yargs.command(
+    'stop',
+    'Stops a deployment, and cleans up',
+    (y) => {
       y.demand('d').
       alias('d', 'deployment-name').
       describe('d', 'Requires a deployment name');
 
-      deployments.stop(y.argv.d).done();
-    })
+      deployments.stop(y.argv.d)
+        .fail(util.cliErr('Error stopping deployment.'))
+        .done();
+    });
+}
 
-    .command('update', 'Updates a deployment in place', (y) => {
+function update(yargs) {
+  return yargs.command(
+    'update',
+    'Updates a deployment in place',
+    (y) => {
       y.demand('d').
       alias('d', 'deployment-name').
       describe('d', 'Requires a deployment name');
 
-      deployments.update(y.argv.d).done();
-    })
+      deployments.update(y.argv.d)
+        .fail(util.cliErr('Error updating deployment.'))
+        .done();
+    });
+}
 
-    .command('generate-deployment', 'Generates a deployment config', (y) => {
+function generateDeployment(yargs) {
+  return yargs.command(
+    'generate-deployment',
+    'Generates a deployment config',
+    (y) => {
       y.demand('d').
       alias('d', 'deployment-name').
       describe('d', 'Requires a deployment name');
 
-      deploymentsFs.generateDeploymentFromName(y.argv.d).done();
-    })
-    .command('generate-ssh-key', 'Adds a new SSH Key', (y) => {
-      y.demand('n').
-      alias('n', 'name').
-      describe('n', 'Creates a new SSH key with the provided name.  The ' +
-        'keypair are stored in ~/.ssh, and the public key is installed into ' +
-        'the project');
+    deploymentsFs.generateDeploymentFromName(y.argv.d)
+      .fail(util.cliErr('Error generating config.'))
+      .done();
+  });
+}
 
-      stdioI.newSshKey(y.argv.n).done();
-    })
-    .command('generate-pass', 'Generate a secure passphrase', () => cn
-      .generatePass()
+function generateSshKey(yargs) {
+  return yargs.command('generate-ssh-key', 'Adds a new SSH Key', (y) => {
+    y.demand('n').
+    alias('n', 'name').
+    describe('n', 'Creates a new SSH key with the provided name.  The ' +
+      'keypair are stored in ~/.ssh, and the public key is installed into ' +
+      'the project');
+
+    stdioI.newSshKey(y.argv.n)
+      .fail(util.cliErr('Error generating SSH key.'))
+      .done();
+  });
+}
+
+function generatePass(yargs) {
+  return yargs.command(
+    'generate-pass',
+    'Generate a secure passphrase',
+    () => cn.generatePass()
       .then((passphrase) => util
         .info('Keep this passphrase secure: ' + passphrase))
-      .fail((err) => util
-        .info('Error generating passphrase: ' + err.message)))
+      .fail(util.cliErr('Error generating passphase.')));
+}
 
-    .command('git-hook-install', 'Install auto-encrypt/decrypt git hooks',
-      callCommandFn(gitHooks.install))
+// Promise?
+function gitHookInstall(yargs) {
+  return yargs.command(
+    'git-hook-install',
+    'Install auto-encrypt/decrypt git hooks',
+    callCommandFn(gitHooks.install));
+}
 
-    .command('git-hook-remove', 'Remove auto-encrypt/decrypt git hooks',
-      callCommandFn(gitHooks.remove))
+// Promise?
+function gitHookRemove(yargs) {
+  return yargs.command(
+    'git-hook-remove',
+    'Remove auto-encrypt/decrypt git hooks',
+    callCommandFn(gitHooks.remove));
+}
 
-    .command('make-private', 'Encrypts private assets (defined in ' +
-      'clusternator.json)', (y) => {
+function makePrivate(yargs) {
+  return yargs.command(
+    'make-private',
+    'Encrypts private assets (defined in clusternator.json)',
+    (y) => {
       demandPassphrase(y);
-
-      privateFs.makePrivate(y.argv.p);
-
-    })
-    .command('read-private', 'Decrypts private assets (defined in ' +
-      'clusternator.json)', (y) => {
-
-      demandPassphrase(y);
-
-      privateFs.readPrivate(y.argv.p).done();
-    })
-
-    .command('cert-upload', 'Upload a new SSL certificate', (y) => {
-      y.demand('n')
-        .alias('n', 'name')
-        .describe('n', 'Unique Name to give the certificate')
-        .demand('p')
-        .alias('p', 'private-key')
-        .describe('p', 'Path to private key')
-        .demand('c')
-        .alias('c', 'certificate')
-        .describe('c', 'Path to signed certificate')
-        .demand('h')
-        .alias('h', 'chain')
-        .describe('h', 'Path to certificate chain')
-        .default('h', '');
-
-      aws.certUpload(y.argv.p, y.argv.c, y.argv.n, y.argv.h)
-        .fail(console.log)
+      return privateFs.makePrivate(y.argv.p)
+        .fail(util.cliErr(
+          'Failed to encrypt private', {
+            ENOENT: { msg: 'project has no private files.', code: 1 }
+          }))
         .done();
-    })
-    .command('cert-delete', 'Destroy an uploaded SSL certificate')
-    .command('cert-list', 'List uploaded SSL certificates', () => cn
-      .certList()
-      .then(console.log))
+    });
+}
 
-    .command('private-checksum', 'Calculates the hash of .private, and ' +
+function readPrivate(yargs) {
+  return yargs.command(
+    'read-private',
+    'Decrypts private assets (defined in clusternator.json)',
+    (y) => {
+      demandPassphrase(y);
+      return privateFs.readPrivate(y.argv.p)
+        .fail(util.cliErr(
+          'Failed to read private', {
+            ENOENT: { msg: 'cannot find clusternator.tar.gz.asc', code: 1 }
+          }))
+        .done();
+    });
+}
+
+function certUpload(yargs) {
+  return yargs.command('cert-upload', 'Upload a new SSL certificate', (y) => {
+    y.demand('n')
+      .alias('n', 'name')
+      .describe('n', 'Unique Name to give the certificate')
+      .demand('p')
+      .alias('p', 'private-key')
+      .describe('p', 'Path to private key')
+      .demand('c')
+      .alias('c', 'certificate')
+      .describe('c', 'Path to signed certificate')
+      .demand('h')
+      .alias('h', 'chain')
+      .describe('h', 'Path to certificate chain')
+      .default('h', '');
+
+    aws.certUpload(y.argv.p, y.argv.c, y.argv.n, y.argv.h)
+      .fail(util.cliErr('Error uploading cert.'))
+      .done();
+  });
+}
+
+function certList(yargs) {
+  return yargs.command(
+    'cert-list',
+    'List uploaded SSL certificates',
+    () => cn.certList()
+      .fail(util.cliErr('Error listing certs.'))
+      .done());
+}
+
+// Promise?
+function privateChecksum(yargs) {
+  return yargs.command(
+    'private-checksum',
+    'Calculates the hash of .private, and ' +
       'writes it to .clusternator/.private-checksum',
-      callCommandFn(privateFs.checksum))
-    .command('private-diff', 'Exits 0 if there is no difference between ' +
+      callCommandFn(privateFs.checksum));
+}
+
+// Promise?
+function privateDiff(yargs) {
+  return yargs.command(
+    'private-diff',
+    'Exits 0 if there is no difference between ' +
       '.clusternator/.private-checksum and a fresh checksum Exits 1 on ' +
       'mismatch, and exits 2 if private-checksum is not found',
-      callCommandFn(privateFs.diff))
-    .command('log', 'Application logs from a user selected server',
-      callCommandFn(stdioI.logApp))
-    .command('log-ecs', 'ECS logs from a user selected server',
-      callCommandFn(stdioI.logEcs))
-    .command('ssh', 'SSH to a selected server', callCommandFn(stdioI.sshShell))
-    .version(() => {
-      const pkg = getPackage();
-      return `Package: ${pkg.version} API: ${API}`;
-    })
-    .help('h')
-    .alias('h', 'help')
-    .argv;
-};
+      callCommandFn(privateFs.diff));
+}
 
-function demandPassphrase(y){
-  return y.demand('p').
-  alias('p', 'passphrase').
-  describe('p', 'Requires a passphrase to encrypt private directory');
+// Promise?
+function log(yargs) {
+  return yargs.command(
+    'log',
+    'Application logs from a user selected server',
+    callCommandFn(stdioI.logApp));
+}
+
+// Promise?
+function logEcs(yargs) {
+  return yargs.command(
+    'log-ecs',
+    'ECS logs from a user selected server',
+    callCommandFn(stdioI.logEcs));
+}
+
+// Promise?
+function ssh(yargs) {
+  return yargs.command(
+    'ssh',
+    'SSH to a selected server',
+    callCommandFn(stdioI.sshShell));
+}
+
+// TODO
+function bootstrap(yargs) {
+  return yargs.command(
+    'bootstrap',
+    'Bootstraps an AWS environment so that projects can be launched into it',
+    () => util.info('TODO: Bootstrap environment.'));
+}
+
+// TODO?
+function certDelete(yargs) {
+  return yargs.command(
+    'cert-delete',
+    'Destroy an uploaded SSL certificate',
+    () => util.info('TODO: Destroy cert.'));
+}
+
+function demandPassphrase(y) {
+  return y.demand('p')
+    .alias('p', 'passphrase')
+    .describe('p', 'Requires a passphrase to encrypt private directory');
 }
 
 function callCommandFn(fn) {

--- a/src/api/0.1/project-fs/private.js
+++ b/src/api/0.1/project-fs/private.js
@@ -184,13 +184,8 @@ function addToIgnore(ignoreFile, privatePath) {
  * @returns {Q.Promise}
  */
 function makePrivate(passphrase) {
-  return clusternatorJson
-    .makePrivate(passphrase)
-    .then(() => {
-      util.info('Clusternator: Private files/directories encrypted');
-    })
-    .fail((err) => util
-      .error(`Clusternator: Failed to encrypt private: ${err.message}`));
+  return clusternatorJson.makePrivate(passphrase)
+    .then(() => util.info('Clusternator: Private files/directories encrypted'));
 }
 
 /**
@@ -198,15 +193,6 @@ function makePrivate(passphrase) {
  * @returns {Q.Promise}
  */
 function readPrivate(passphrase) {
-  return clusternatorJson.readPrivate(passphrase).then(() => {
-    util.info('Clusternator: Private files/directories un-encrypted');
-  })
-    .fail((err) => {
-      if (err.code === 'ENONENT') {
-        util.Error('Clusternator cannot find encrypted .private folder ' +
-          '(clusternator.tar.gz.asc');
-      } else {
-        util.error('Clusternator error reading file: ');
-      }
-    });
+  return clusternatorJson.readPrivate(passphrase)
+    .then(() => util.info('Clusternator: Private files un-encrypted'));
 }

--- a/src/util.js
+++ b/src/util.js
@@ -36,7 +36,8 @@ module.exports = {
   safeParse,
   isObject,
   deepFreeze,
-  partial
+  partial,
+  cliErr
 };
 
 /**
@@ -374,3 +375,40 @@ function makeRetryPromiseFunction(promiseReturningFunction, retryCount, delay,
   return promiseToRetry;
 }
 
+/**
+ * Intended to handle errors at the CLI level.
+ *
+ * Pretty-prints messages for specific error codes and decides whether to
+ * exit with 0 or 1.
+ *
+ * @param {string} operationDescription Describes what's being done in the CLI.
+ * @param {codeMap} maps error codes to messages.
+ *
+ * If codeMap is omitted, or doesn't match an actual error, error.message will
+ * be logged instead.
+ *
+ * Example:
+ *
+ * .fail(cliErr('Doing something with clusternator', {
+ *   ENOENT: { msg: 'something not found', code: 1 },
+ *   EACCES: { msg: 'no big deal' }
+ * }));
+ */
+function cliErr(
+  operationDescription,
+  codeMap) {
+
+  return function(error) {
+    const info = codeMap[error.code];
+    const code = info ? info.code : 1;
+
+    if (info) {
+      winston.info(operationDescription + ':', info.msg);
+    }
+    else {
+      winston.error(operationDescription + ':', error);
+    }
+
+    process.exit(code);
+  };
+}


### PR DESCRIPTION
Trying to make the CLI code easier to deal with.

1. Split the big mess of yargs soup into a function for each command.
2. These functions are composed together and applied to the yargs instance
3. These functions are also exported from `cli-args.js` so they can be unit tested.
4. Error handling is now centralized at the yargs layer as well, using `utils.cliErr`, when lets you map messages and exit codes to particular errors.

The idea is that mid-level service could should just throw exceptions, and the handing will be done at the cli level.