### PR TITLE
attempt to clean up cli

### DIFF
--- a/bin-src/clusternator-cli.js
+++ b/bin-src/clusternator-cli.js
@@ -14,5 +14,5 @@ const API = USER ?
 
 const yargs = require('yargs');
 
-require(`../lib/api/${API}/cli/cli-api`)(yargs);
-
+const cli = require(`../lib/api/${API}/cli/cli-api`);
+cli.configure(yargs);

--- a/src/api/0.1/cli/cli-api.js
+++ b/src/api/0.1/cli/cli-api.js
@@ -1,15 +1,16 @@
 'use strict';
+
 /**
- * This is the primary interface to the {@link module:clusternatorCli} stub
+ * This is the primary interface to the {@link module:clusternatorCli}.
  *
- * This module uses yargs to communicate with the user/CLI and has no utility
- * outside of being the place to configure the CLI arguments.
+ * This module is responsible for parsing arguments and handling errors only.
+ * Any actual logic is delegated to internal modules.
  *
  * @module api/'0.1'/cli
  */
-
 const API = '0.1';
 
+const R = require('ramda');
 const path = require('path');
 
 const cmn = require('../common');
@@ -30,55 +31,162 @@ const dockerFs = require('../project-fs/docker');
 const deploymentsFs = require('../project-fs/deployments');
 const gitHooks = require('../project-fs/git-hooks');
 
-const getPackage = () => require('../../../../package.json');
+const pkg = require('../../../../package.json');
 
+module.exports = {
+  configure: function(yargs) {
+    const applyCommands = R.pipe.apply(null, R.values(this.commands));
+    applyCommands(yargs);
+    util.cliLogger(yargs);
 
-module.exports = (yargs) => {
+    yargs
+      .usage('Usage: $0 <command> [opts]')
+      .completion('completion', 'Generate bash completions')
+      .version(() => `Package: ${pkg.version} API: ${API}`)
+      .help('h')
+      .alias('h', 'help')
+      .argv;
+  },
 
-  util.cliLogger(yargs);
+  // Exposed for unit testing.
+  commands: {
+    bootstrap,
+    init,
+    generateDeployment,
+    generateSshKey,
+    generatePass,
+    gitHookInstall,
+    gitHookRemove,
+    config,
+    projectCommands,
+    createUser,
+    login,
+    passwd,
+    certUpload,
+    certDelete,
+    certList,
+    serve,
+    listAuthorities,
+    listProjects,
+    describeServices,
+    build,
+    deploy,
+    stop,
+    update,
+    makePrivate,
+    readPrivate,
+    privateChecksum,
+    privateDiff,
+    log,
+    logEcs,
+    ssh
+  }
+};
 
-  yargs.usage('Usage: $0 <command> [opts]');
-
-  const argv = yargs
-    .completion('completion', 'Generate bash completions')
-    .command('bootstrap', 'Bootstraps an AWS environment so that projects ' +
-      'can be launched into it', () => util.info('Bootstrap environment'))
-    .command('init', 'Initializes a `.clusternator` file in the project ' +
+function init(yargs) {
+  return yargs.command(
+    'init',
+    'Initializes a `.clusternator` file in the project ' +
       'repo, and provisions AWS networking resources.  Requires AWS ' +
-      'credentials', (y) => {
+      'credentials',
+    (y) => {
       y.demand('o')
         .alias('o', 'offline')
         .default('o', false)
         .describe('o', 'offline only, makes "clusternator.json" but does ' +
           '*not* check the cloud infrastructure');
 
-      project.init(y.argv.o).done();
-    })
-    .command('project', 'Project management commands (try ' +
-      'clusternator project --help)',
-      (y) => {
-        const argv = y.usage('Usage: $0 project <command> [opts]')
-          .command('create-data', 'create project db entry',
-            () => projectDb.createData().done())
-          .command('git-hub-key', 'Display GitHub key ' +
-            '(warning returns secret GitHub key)',
-            () => projectDb.getGitHub().done())
-          .command('shared-key', 'Display shared key ' +
-            '(warning returns secret shared key)',
-            () => projectDb.getShared().done())
-          .command('reset-auth-token', 'Reset authentication token',
-            () => projectDb.resetAuth().done())
-          .command('reset-git-hub-key', 'Reset GitHub key',
-            () => projectDb.resetGitHub().done())
-          .command('reset-shared-key', 'Reset shared key',
-            () => projectDb.resetShared().done())
-          .help('h')
-          .alias('h', 'help')
-          .argv;
-      })
-    .command('config', 'Configure the local clusternator user',
-      () => Config.interactiveUser().done())
-    .command('create-user', 'Create a user on the clusternator server', (y) => {
+      project.init(y.argv.o)
+        .fail(util.cliErr('Failed to initialize project.'))
+        .done();
+    });
+}
+
+function projectCommands(yargs) {
+  return yargs.command(
+    'project',
+    'Project management commands (try clusternator project --help)',
+    (y) => {
+      const applySubCommands = R.pipe(
+        project_createData,
+        project_gitHubKey,
+        project_sharedKey,
+        project_resetAuthToken,
+        project_resetGitHubKey,
+        project_resetSharedKey);
+
+      const argv = applySubCommands(y)
+        .usage('Usage: $0 project <command> [opts]')
+        .help('h')
+        .alias('h', 'help')
+        .argv;
+    });
+}
+
+function project_createData(yargs) {
+  return yargs.command(
+    'create-data',
+    'create project db entry',
+    () => projectDb.createData()
+      .fail(util.cliErr('Failed to create project data.'))
+      .done());
+}
+
+function project_gitHubKey(yargs) {
+  return yargs.command(
+    'git-hub-key',
+    'Display GitHub key (warning: returns secret GitHub key)',
+    () => projectDb.getGitHub()
+      .fail(util.cliErr('Failed to locate github key.'))
+      .done());
+}
+
+function project_sharedKey(yargs) {
+  return yargs.command(
+    'shared-key',
+    'Display shared key (warning: returns secret shared key)',
+    () => projectDb.getShared()
+      .fail(util.cliErr('Failed to locate shared key.'))
+      .done());
+}
+
+function project_resetAuthToken(yargs) {
+  return yargs.command(
+    'reset-auth-token',
+    'Reset authentication token',
+    () => projectDb.resetAuth()
+      .fail(util.cliErr('Failed to reset auth token.'))
+      .done());
+}
+
+function project_resetGitHubKey(yargs) {
+  return yargs.command(
+    'reset-git-hub-key',
+    'Reset GitHub key',
+    () => projectDb.resetGitHub()
+      .fail(util.cliErr('Failed to reset github key.'))
+      .done());
+}
+
+function project_resetSharedKey(yargs) {
+  return yargs.command('reset-shared-key', 'Reset shared key',
+    () => projectDb.resetShared()
+      .fail(util.cliErr('Failed to reset shared key.'))
+      .done());
+}
+
+function config(yargs) {
+  return yargs.command('config', 'Configure the local clusternator user',
+    () => Config.interactiveUser()
+      .fail(util.cliErr('Failed to configure local user.'))
+      .done());
+}
+
+function createUser(yargs) {
+  return yargs.command(
+    'create-user',
+    'Create a user on the clusternator server',
+    (y) => {
       y.demand('n')
         .alias('n', 'username')
         .describe('n', 'Username for the account')
@@ -97,86 +205,123 @@ module.exports = (yargs) => {
         .describe('a', 'authority of the user {number} lower numbers have ' +
           'more authority than higher number');
       user.createUser(y.argv.n, y.argv.p, y.argv.c, y.argv.a)
-        .fail((err) => console
-          .log(`Error creating user: ${err.message}`))
+        .fail(util.cliErr('Error creating user.'))
         .done();
-    })
-    .command('login', 'Login to the clusternator server',
-      (y) =>  {
-        y.demand('p')
-          .alias('p', 'password')
-          .describe('p', 'your password (be careful with shell entry like ' +
-            'this)')
-          .default('p', '')
-          .demand('u')
-          .alias('u', 'user-name')
-          .describe('u', 'user name to login with, (defaults to local config ' +
-            'if available)')
-          .default('u', '');
+    });
+}
 
-        return user.login(y.argv.u, y.argv.p).fail((err) => console
-          .log(`Error logging in: ${err.message}`))
-          .done();
-      })
-    .command('passwd', 'Change your clusternator server password',
-      (y) => {
-        y.demand('p')
-          .alias('p', 'password')
-          .describe('your password (be careful with shell entry like this)')
-          .default('p', '')
-          .demand('n')
-          .alias('n', 'new-password')
-          .describe('n', 'your NEW password (be careful with shell entry ' +
-            'like this)')
-          .default('n', '')
-          .demand('c')
-          .alias('c', 'confirm-password')
-          .describe('c', 'confirm your NEW password')
-          .default('c', '')
-          .demand('u')
-          .alias('u', 'user-name')
-          .describe('u', 'user name to login with')
-          .default('u', '');
+function login(yargs) {
+  return yargs.command('login', 'Login to the clusternator server',
+  (y) =>  {
+    y.demand('p')
+      .alias('p', 'password')
+      .describe('p', 'your password (be careful with shell entry like ' +
+        'this)')
+      .default('p', '')
+      .demand('u')
+      .alias('u', 'user-name')
+      .describe('u', 'user name to login with, (defaults to local config ' +
+        'if available)')
+      .default('u', '');
 
-        return user.changePassword(y.argv.u, y.argv.p, y.argv.n, y.argv.c)
-          .fail((err) => console
-            .log(`Error logging in: ${err.message}`))
-          .done();
-      })
-    .command('serve', 'Start a clusternator server. (typically prefer npm ' +
-      'start, or serve.sh', () =>  {
+    return user.login(y.argv.u, y.argv.p)
+      .fail(util.cliErr('Error logging in.'))
+      .done();
+  });
+}
+
+function passwd(yargs) {
+  return yargs.command('passwd', 'Change your clusternator server password',
+  (y) => {
+    y.demand('p')
+      .alias('p', 'password')
+      .describe('your password (be careful with shell entry like this)')
+      .default('p', '')
+      .demand('n')
+      .alias('n', 'new-password')
+      .describe('n', 'your NEW password (be careful with shell entry ' +
+        'like this)')
+      .default('n', '')
+      .demand('c')
+      .alias('c', 'confirm-password')
+      .describe('c', 'confirm your NEW password')
+      .default('c', '')
+      .demand('u')
+      .alias('u', 'user-name')
+      .describe('u', 'user name to login with')
+      .default('u', '');
+
+    return user.changePassword(y.argv.u, y.argv.p, y.argv.n, y.argv.c)
+      .fail(util.cliErr('Error changing password.'))
+      .done();
+  });
+}
+
+// Promise?
+function serve(yargs) {
+  return yargs.command(
+    'serve',
+    'Start a clusternator server (i.e. \'npm start\' or \'serve.sh\'',
+    () =>  {
       const config = Config();
       return cn.startServer(config);
-    })
-    .command('list-authorities', 'List your Clusternator server\'s authorities',
-      callCommandFn(authorities.list))
+    });
+}
 
-    .command('list-projects', 'List projects with clusternator resources',
-      (y) => aws
-        .listProjects()
-        .then((projectNames) => projectNames
-          .forEach(console.log))
-        .done())
-    .command('describe-services', 'Describe project services', callCommandFn(aws
-      .describeServices))
-    .command('build', 'Local Docker Build', (y) => {
+function listAuthorities(yargs) {
+  return yargs.command(
+    'list-authorities',
+    'List your Clusternator server\'s authorities',
+    () => authorities.list()
+      .fail(util.cliErr('Error listing authorities'))
+      .done());
+}
+
+function listProjects(yargs) {
+  return yargs.command(
+    'list-projects',
+    'List projects with clusternator resources',
+    (y) => aws.listProjects()
+      .then((projectNames) => projectNames.forEach(console.log))
+      .fail(util.cliErr('Error listing projects.'))
+      .done());
+}
+
+function describeServices(yargs) {
+  return yargs.command(
+    'describe-services',
+    'Describe project services',
+    () => aws.describeServices()
+      .fail(util.cliErr(`Error describing services`))
+      .done());
+}
+
+function build(yargs) {
+  return yargs.command(
+    'build',
+    'Local Docker Build',
+    (y) => {
       const id = (+Date.now()).toString(16);
       const argv = demandPassphrase(y)
-          .demand('i')
-          .alias('i', 'image')
-          .describe('i', 'Name of the docker image to create')
-          .default('i', id)
-          .argv;
+        .demand('i')
+        .alias('i', 'image')
+        .describe('i', 'Name of the docker image to create')
+        .default('i', id)
+        .argv;
 
       util.info('Building Docker Image: ', argv.i);
 
-      return dockerFs
-        .build(argv.i, argv.p).fail((err) => {
-          util.error('Error building local Docker image: ', err);
-        }).done();
-    })
+      return dockerFs.build(argv.i, argv.p)
+        .fail(util.cliErr('Error building local Docker image'))
+        .done();
+    });
+}
 
-    .command('deploy', 'Makes a deployment', (y) => {
+function deploy(yargs) {
+  return yargs.command(
+    'deploy',
+    'Makes a deployment',
+    (y) => {
       y.demand('d').
       alias('d', 'deployment-name').
       describe('d', 'Requires a deployment name');
@@ -189,123 +334,224 @@ module.exports = (yargs) => {
        .alias('u', 'update')
        .describe('u', 'Forces teardown if deployment exists.');
 
-      deployments.deploy(y.argv.d, y.argv.f, y.argv.u).done();
-    })
-
-    .command('stop', 'Stops a deployment, and cleans up', (y) => {
-      y.demand('d').
-      alias('d', 'deployment-name').
-      describe('d', 'Requires a deployment name');
-
-      deployments.stop(y.argv.d).done();
-    })
-
-    .command('update', 'Updates a deployment in place', (y) => {
-      y.demand('d').
-      alias('d', 'deployment-name').
-      describe('d', 'Requires a deployment name');
-
-      deployments.update(y.argv.d).done();
-    })
-
-    .command('generate-deployment', 'Generates a deployment config', (y) => {
-      y.demand('d').
-      alias('d', 'deployment-name').
-      describe('d', 'Requires a deployment name');
-
-      deploymentsFs.generateDeploymentFromName(y.argv.d).done();
-    })
-    .command('generate-ssh-key', 'Adds a new SSH Key', (y) => {
-      y.demand('n').
-      alias('n', 'name').
-      describe('n', 'Creates a new SSH key with the provided name.  The ' +
-        'keypair are stored in ~/.ssh, and the public key is installed into ' +
-        'the project');
-
-      stdioI.newSshKey(y.argv.n).done();
-    })
-    .command('generate-pass', 'Generate a secure passphrase', () => cn
-      .generatePass()
-      .then((passphrase) => util
-        .info('Keep this passphrase secure: ' + passphrase))
-      .fail((err) => util
-        .info('Error generating passphrase: ' + err.message)))
-
-    .command('git-hook-install', 'Install auto-encrypt/decrypt git hooks',
-      callCommandFn(gitHooks.install))
-
-    .command('git-hook-remove', 'Remove auto-encrypt/decrypt git hooks',
-      callCommandFn(gitHooks.remove))
-
-    .command('make-private', 'Encrypts private assets (defined in ' +
-      'clusternator.json)', (y) => {
-      demandPassphrase(y);
-
-      privateFs.makePrivate(y.argv.p);
-
-    })
-    .command('read-private', 'Decrypts private assets (defined in ' +
-      'clusternator.json)', (y) => {
-
-      demandPassphrase(y);
-
-      privateFs.readPrivate(y.argv.p).done();
-    })
-
-    .command('cert-upload', 'Upload a new SSL certificate', (y) => {
-      y.demand('n')
-        .alias('n', 'name')
-        .describe('n', 'Unique Name to give the certificate')
-        .demand('p')
-        .alias('p', 'private-key')
-        .describe('p', 'Path to private key')
-        .demand('c')
-        .alias('c', 'certificate')
-        .describe('c', 'Path to signed certificate')
-        .demand('h')
-        .alias('h', 'chain')
-        .describe('h', 'Path to certificate chain')
-        .default('h', '');
-
-      aws.certUpload(y.argv.p, y.argv.c, y.argv.n, y.argv.h)
-        .fail(console.log)
+      deployments.deploy(y.argv.d, y.argv.f, y.argv.u)
+        .fail(util.cliErr('Error deploying.'))
         .done();
-    })
-    .command('cert-delete', 'Destroy an uploaded SSL certificate')
-    .command('cert-list', 'List uploaded SSL certificates', () => cn
-      .certList()
-      .then(console.log))
-
-    .command('private-checksum', 'Calculates the hash of .private, and ' +
-      'writes it to .clusternator/.private-checksum',
-      callCommandFn(privateFs.checksum))
-    .command('private-diff', 'Exits 0 if there is no difference between ' +
-      '.clusternator/.private-checksum and a fresh checksum Exits 1 on ' +
-      'mismatch, and exits 2 if private-checksum is not found',
-      callCommandFn(privateFs.diff))
-    .command('log', 'Application logs from a user selected server',
-      callCommandFn(stdioI.logApp))
-    .command('log-ecs', 'ECS logs from a user selected server',
-      callCommandFn(stdioI.logEcs))
-    .command('ssh', 'SSH to a selected server', callCommandFn(stdioI.sshShell))
-    .version(() => {
-      const pkg = getPackage();
-      return `Package: ${pkg.version} API: ${API}`;
-    })
-    .help('h')
-    .alias('h', 'help')
-    .argv;
-};
-
-function demandPassphrase(y){
-  return y.demand('p').
-  alias('p', 'passphrase').
-  describe('p', 'Requires a passphrase to encrypt private directory');
+    });
 }
 
-function callCommandFn(fn) {
-  return (y) => {
-    const argv = y.help('h').alias('h', 'help').argv;
-    fn();
-  };
+function stop(yargs) {
+  return yargs.command(
+    'stop',
+    'Stops a deployment, and cleans up',
+    (y) => {
+      y.demand('d').
+      alias('d', 'deployment-name').
+      describe('d', 'Requires a deployment name');
+
+      deployments.stop(y.argv.d)
+        .fail(util.cliErr('Error stopping deployment.'))
+        .done();
+    });
+}
+
+function update(yargs) {
+  return yargs.command(
+    'update',
+    'Updates a deployment in place',
+    (y) => {
+      y.demand('d').
+      alias('d', 'deployment-name').
+      describe('d', 'Requires a deployment name');
+
+      deployments.update(y.argv.d)
+        .fail(util.cliErr('Error updating deployment.'))
+        .done();
+    });
+}
+
+function generateDeployment(yargs) {
+  return yargs.command(
+    'generate-deployment',
+    'Generates a deployment config',
+    (y) => {
+      y.demand('d').
+      alias('d', 'deployment-name').
+      describe('d', 'Requires a deployment name');
+
+    deploymentsFs.generateDeploymentFromName(y.argv.d)
+      .fail(util.cliErr('Error generating config.'))
+      .done();
+  });
+}
+
+function generateSshKey(yargs) {
+  return yargs.command('generate-ssh-key', 'Adds a new SSH Key', (y) => {
+    y.demand('n').
+    alias('n', 'name').
+    describe('n', 'Creates a new SSH key with the provided name.  The ' +
+      'keypair are stored in ~/.ssh, and the public key is installed into ' +
+      'the project');
+
+    stdioI.newSshKey(y.argv.n)
+      .fail(util.cliErr('Error generating SSH key.'))
+      .done();
+  });
+}
+
+function generatePass(yargs) {
+  return yargs.command(
+    'generate-pass',
+    'Generate a secure passphrase',
+    () => cn.generatePass()
+      .then((passphrase) => util
+        .info('Keep this passphrase secure: ' + passphrase))
+      .fail(util.cliErr('Error generating passphase.')));
+}
+
+function gitHookInstall(yargs) {
+  return yargs.command(
+    'git-hook-install',
+    'Install auto-encrypt/decrypt git hooks',
+    () => gitHooks.install()
+      .done());
+}
+
+function gitHookRemove(yargs) {
+  return yargs.command(
+    'git-hook-remove',
+    'Remove auto-encrypt/decrypt git hooks',
+    () => gitHooks.remove()
+      .done());
+}
+
+function makePrivate(yargs) {
+  return yargs.command(
+    'make-private',
+    'Encrypts private assets (defined in clusternator.json)',
+    (y) => {
+      demandPassphrase(y);
+      return privateFs.makePrivate(y.argv.p)
+        .fail(util.cliErr(
+          'Failed to encrypt private', {
+            ENOENT: { msg: 'project has no private files.', code: 1 }
+          }))
+        .done();
+    });
+}
+
+function readPrivate(yargs) {
+  return yargs.command(
+    'read-private',
+    'Decrypts private assets (defined in clusternator.json)',
+    (y) => {
+      demandPassphrase(y);
+      return privateFs.readPrivate(y.argv.p)
+        .fail(util.cliErr(
+          'Failed to read private', {
+            ENOENT: { msg: 'cannot find clusternator.tar.gz.asc', code: 1 }
+          }))
+        .done();
+    });
+}
+
+function certUpload(yargs) {
+  return yargs.command('cert-upload', 'Upload a new SSL certificate', (y) => {
+    y.demand('n')
+      .alias('n', 'name')
+      .describe('n', 'Unique Name to give the certificate')
+      .demand('p')
+      .alias('p', 'private-key')
+      .describe('p', 'Path to private key')
+      .demand('c')
+      .alias('c', 'certificate')
+      .describe('c', 'Path to signed certificate')
+      .demand('h')
+      .alias('h', 'chain')
+      .describe('h', 'Path to certificate chain')
+      .default('h', '');
+
+    aws.certUpload(y.argv.p, y.argv.c, y.argv.n, y.argv.h)
+      .fail(util.cliErr('Error uploading cert.'))
+      .done();
+  });
+}
+
+function certList(yargs) {
+  return yargs.command(
+    'cert-list',
+    'List uploaded SSL certificates',
+    () => cn.certList()
+      .fail(util.cliErr('Error listing certs.'))
+      .done());
+}
+
+function privateChecksum(yargs) {
+  return yargs.command(
+    'private-checksum',
+    'Calculates the hash of .private, and ' +
+      'writes it to .clusternator/.private-checksum',
+    () => privateFs.checksum()
+      .fail(util.cliErr('Error computing private checksum.'))
+      .done());
+}
+
+function privateDiff(yargs) {
+  return yargs.command(
+    'private-diff',
+    'Exits 0 if there is no difference between ' +
+      '.clusternator/.private-checksum and a fresh checksum Exits 1 on ' +
+      'mismatch, and exits 2 if private-checksum is not found',
+    () => privateFs.diff()
+    .fail(util.cliErr('Error computing private checksum.'))
+      .done());
+}
+
+function log(yargs) {
+  return yargs.command(
+    'log',
+    'Application logs from a user selected server',
+    () => stdioI.logApp()
+      .fail(util.cliErr('Error displaying logs.'))
+      .done());
+}
+
+function logEcs(yargs) {
+  return yargs.command(
+    'log-ecs',
+    'ECS logs from a user selected server',
+    () => stdioI.logEcs()
+      .fail(util.cliErr('Error displaying ECS logs.'))
+      .done());
+}
+
+function ssh(yargs) {
+  return yargs.command(
+    'ssh',
+    'SSH to a selected server',
+    () => stdioI.sshShell()
+      .fail(util.cliErr('Error connecting with SSH.'))
+      .done());
+}
+
+// TODO
+function bootstrap(yargs) {
+  return yargs.command(
+    'bootstrap',
+    'Bootstraps an AWS environment so that projects can be launched into it',
+    () => util.info('TODO: Bootstrap environment.'));
+}
+
+// TODO
+function certDelete(yargs) {
+  return yargs.command(
+    'cert-delete',
+    'Destroy an uploaded SSL certificate',
+    () => util.info('TODO: Destroy cert.'));
+}
+
+function demandPassphrase(y) {
+  return y.demand('p')
+    .alias('p', 'passphrase')
+    .describe('p', 'Requires a passphrase to encrypt private directory');
 }

--- a/src/api/0.1/cli/cli-authorities.js
+++ b/src/api/0.1/cli/cli-authorities.js
@@ -45,8 +45,5 @@ function logObject(obj, prefix) {
 function list() {
   return cn
     .listAuthorities()
-    .then(logObject)
-    .fail((err) => {
-      console.log(`Error listing authorities: ${err.message}`);
-    });
+    .then(logObject);
 }

--- a/src/api/0.1/cli/cli-authorities.spec.js
+++ b/src/api/0.1/cli/cli-authorities.spec.js
@@ -26,11 +26,4 @@ describe('CLI Authorities Middleware', () => {
   it('listAuthorities should resolve if clusternator API resolves', (done) => {
     C.checkResolve(a.list, done);
   });
-
-  it('listAuthorities should swallow rejections if clusternator API rejects ' +
-    '(CLI Endpoint)', (done) => {
-    authorities = new Error('test');
-    C.checkResolve(a.list, done);
-  });
-
 });

--- a/src/api/0.1/cli/cloud-service.js
+++ b/src/api/0.1/cli/cloud-service.js
@@ -19,13 +19,11 @@ module.exports = {
  * @returns {Q.Promise}
  */
 function describeServices() {
-
   return clusternatorJson
     .get()
     .then((config) => cn
       .describeServices(config.projectId)
-      .then((results) => JSON.stringify(results, null, 2)))
-    .fail((err) => console.log(`Error: ${err.message} ${err.stack}`));
+      .then((results) => JSON.stringify(results, null, 2)));
 }
 
 /**

--- a/src/api/0.1/cli/deployments.js
+++ b/src/api/0.1/cli/deployments.js
@@ -61,9 +61,7 @@ function update(name) {
         .fail(getAppDefNotFound(dPath))
         .then((results) => cn
           .update(name, cJson.projectId, results));
-    })
-    .fail((err) => util
-      .error(`Failed to update deployment: ${err.message}`));
+    });
 }
 
 /**
@@ -94,4 +92,3 @@ function getAppDefNotFound(dPath) {
     throw err;
   };
 }
-

--- a/src/api/0.1/cli/project-db.js
+++ b/src/api/0.1/cli/project-db.js
@@ -64,46 +64,40 @@ function createData(channel) {
     .then((results) => {
       logCreateData(results);
       return privateFs.writeClusternatorCreds(results.authToken);
-    })
-    .fail((err) => logError('creating Project Data', err.message));
+    });
 }
 
 function resetAuth() {
   return getProjectId()
     .then((projectId) => cn
       .resetProjectAuth(projectId))
-    .then(log)
-    .fail((err) => logError('resetting auth token', err.message));
+    .then(log);
 }
 
 function resetShared() {
   return getProjectId()
     .then((projectId) => cn
       .resetProjectShared(projectId))
-    .then(log)
-    .fail((err) => logError('resetting shared key', err.message));
+    .then(log);
 }
 
 function resetGitHub() {
   return getProjectId()
     .then((projectId) => cn
       .resetProjectGitHub(projectId))
-    .then(log)
-    .fail((err) => logError('resetting GitHub key', err.message));
+    .then(log);
 }
 
 function getShared() {
   return getProjectId()
     .then((projectId) => cn
       .getProjectShared(projectId))
-    .then(log)
-    .fail((err) => logError('getting shared key', err.message));
+    .then(log);
 }
 
 function getGitHub() {
   return getProjectId()
     .then((projectId) => cn
       .getProjectGitHub(projectId))
-    .then(log)
-    .fail((err) => logError('getting GitHub key', err.message));
+    .then(log);
 }

--- a/src/api/0.1/project-fs/docker.js
+++ b/src/api/0.1/project-fs/docker.js
@@ -6,8 +6,8 @@
  * @module api/'0.1'/projectFs/docker
  */
 const DOCKERFILE = 'Dockerfile';
-const DOCKERFILE_NODE_LTS_LATEST = 'Dockerfile-node-4-latest';
-const DOCKERFILE_NODE_STABLE_LATEST = 'Dockerfile-node-5-latest';
+const DOCKERFILE_NODE_LTS_LATEST = 'Dockerfile-node-lts-latest';
+const DOCKERFILE_NODE_STABLE_LATEST = 'Dockerfile-node-stable-latest';
 const DOCKERFILE_STATIC_LATEST = 'dockerfile-static-latest';
 const CLUSTERNATOR_DIR = /\$CLUSTERNATOR_DIR/g;
 const EXTERNAL_PORT = /\$EXTERNAL_PORT/g;

--- a/src/api/0.1/project-fs/private.js
+++ b/src/api/0.1/project-fs/private.js
@@ -184,13 +184,8 @@ function addToIgnore(ignoreFile, privatePath) {
  * @returns {Q.Promise}
  */
 function makePrivate(passphrase) {
-  return clusternatorJson
-    .makePrivate(passphrase)
-    .then(() => {
-      util.info('Clusternator: Private files/directories encrypted');
-    })
-    .fail((err) => util
-      .error(`Clusternator: Failed to encrypt private: ${err.message}`));
+  return clusternatorJson.makePrivate(passphrase)
+    .then(() => util.info('Clusternator: Private files/directories encrypted'));
 }
 
 /**
@@ -198,15 +193,6 @@ function makePrivate(passphrase) {
  * @returns {Q.Promise}
  */
 function readPrivate(passphrase) {
-  return clusternatorJson.readPrivate(passphrase).then(() => {
-    util.info('Clusternator: Private files/directories un-encrypted');
-  })
-    .fail((err) => {
-      if (err.code === 'ENONENT') {
-        util.Error('Clusternator cannot find encrypted .private folder ' +
-          '(clusternator.tar.gz.asc');
-      } else {
-        util.error('Clusternator error reading file: ');
-      }
-    });
+  return clusternatorJson.readPrivate(passphrase)
+    .then(() => util.info('Clusternator: Private files un-encrypted'));
 }


### PR DESCRIPTION
Trying to make the CLI code easier to deal with.

* Split the big mess of yargs soup into a function for each command.
* These functions are composed together and applied to the yargs instance
* These functions are also exported from cli-args.js so they can be unit tested.
* Error handling is now centralized at the yargs layer as well, using utils.cliErr, which lets you map messages and exit codes to particular errors.

The idea is that mid-level service could should just throw exceptions, and the handing will be done at the cli level.

Connected to #96