### PR TITLE
Don't put the literal shared key in the git hooks.

### DIFF
--- a/src/api/0.1/project-fs/skeletons/git-post-commit
+++ b/src/api/0.1/project-fs/skeletons/git-post-commit
@@ -6,4 +6,4 @@ set -e
 # Locate *this* file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-clusternator read-private -p $CLUSTERNATOR_PASS
+clusternator read-private -p $(clusternator project shared-key)

--- a/src/api/0.1/project-fs/skeletons/git-post-merge
+++ b/src/api/0.1/project-fs/skeletons/git-post-merge
@@ -6,4 +6,4 @@ set -e
 # Locate *this* file
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-clusternator read-private -p $CLUSTERNATOR_PASS
+clusternator read-private -p $(clusternator project shared-key)

--- a/src/api/0.1/project-fs/skeletons/git-pre-commit
+++ b/src/api/0.1/project-fs/skeletons/git-pre-commit
@@ -15,10 +15,10 @@ else
   cd $DIR
   cd ../../
   rm -f ./clusternator.tar.gz.asc
-  clusternator make-private -p $CLUSTERNATOR_PASS
+  clusternator make-private -p $(clusternator project shared-key)
   clusternator private-checksum
   git add ./clusternator.tar.gz.asc
-  # note adding .private-checksum to .clusternator litarally
+  # note adding .private-checksum to .clusternator literally
   # is _not_ good practice as .clusternator is "configurable"
   git add ./.clusternator/.private-checksum
 


### PR DESCRIPTION
We want to reduce the number of places where it can be found for security reasons.

We also want to avoid problems where you change the key and your git hooks break.

Fixes #300
Connected to #303