### PR TITLE
Basic "lite version" (hack) of ZDU is in place Fixes #294

### DIFF
--- a/src/aws/aws-constants.js
+++ b/src/aws/aws-constants.js
@@ -28,8 +28,8 @@ const EXPORTS = {
     'arn:aws:iam::731670193630:server-certificate/clusternator-wildcard',
   AWS_RETRY_DELAY: 1500,
   AWS_RETRY_LIMIT: 3,
-  AWS_RETRY_MULTIPLIER: 3
-
+  AWS_RETRY_MULTIPLIER: 3,
+  ALT_TAG: '-alt'
 };
 
 module.exports = util.deepFreeze(EXPORTS);

--- a/src/aws/common.spec.js
+++ b/src/aws/common.spec.js
@@ -298,4 +298,94 @@ describe('common AWS functions', () => {
     expect(common.qualifyUrl({ tld: 'org' }, 'hello') === 'hello.org')
       .to.be.ok;
   });
+
+  describe('filterClusterListForName function', () => {
+    it('should return a function', () => {
+      expect(typeof common.filterClusterListForName('hi')).to.equal('function');
+    }); 
+    
+    it('s returned function should match name if last string after / in ' +
+      'given list matches name', () => {
+      const filter = common.filterClusterListForName('hello');
+      expect(filter('something/something/hello')).to.equal(true);
+    });
+  });
+
+  describe('processZduClusterResults function', () => {
+    it('should return a function', () => {
+      expect(typeof common.processZduClusterResults('name'))
+        .to.equal('function');
+    }); 
+    
+    it('s returned function should throw if results[0]/[1] are both empty ' +
+      'arrays', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([[], []])).to.throw(Error);
+    });
+    
+    it('s returned function should throw if results[2]/[3] are both empty ' +
+      'arrays', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([['1'], [], [], []])).to.throw(Error);
+    });
+    
+    it('s returned function should throw if results[0]/[1] are both full ' +
+      'arrays', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([['1'], ['1'], ['1'], []])).to.throw(Error);
+    });
+    
+    it('s returned function should throw if results[2]/[3] are both full ' +
+      'arrays', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([['1'], [], ['1'], ['1']])).to.throw(Error);
+    });
+    
+    it('s returned function should throw if result[0] exists and result[2] ' +
+      'does not', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([['1'], [], [], ['1']])).to.throw(Error);
+      
+    });
+    
+    it('s returned function should throw if result[0] does not exist and ' +
+      'result[2] exists', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([[], ['1'], ['1'], []])).to.throw(Error);
+    });
+    
+    it('s returned function should throw if result[1] exists and result[3] ' +
+      'does not', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([[], ['1'], ['1'], []])).to.throw(Error);
+    });
+    
+    it('s returned function should throw if result[1] does not exist and ' +
+      'result[3] exists', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(() => fn([['1'], [], [], ['1']])).to.throw(Error);
+    });
+    
+    it('should return the alt name if the original name exists', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(fn([['1'], [], ['1'], []])).to.deep.equal({ 
+        clusterNameExisting: 'name',
+        clusterNameNew: 'name-alt'
+      });
+    });
+    
+    it('should return the original name if the alt name exists', () => {
+      const fn = common.processZduClusterResults('name');
+      expect(fn([[], ['1'], [], ['1']])).to.deep.equal({
+        clusterNameExisting: 'name-alt',
+        clusterNameNew: 'name'
+      });
+    });
+  });
+
+  describe('zduClusterNames function', () => {
+    it('should return a function', () => {
+      expect(typeof common.zduClusterNames()).to.equal('function');
+    }); 
+  });
 });

--- a/src/aws/ec2/vm/vm-ecs.js
+++ b/src/aws/ec2/vm/vm-ecs.js
@@ -21,6 +21,7 @@ module.exports = {
   createPr,
   describeDeployment: vm.describeDeployment,
   describePr: vm.describePr,
+  destroy: vm.destroy,
   destroyDeployment: vm.destroyDeployment,
   destroyPr: vm.destroyPr,
   listDeployment: vm.listDeployment,
@@ -33,36 +34,32 @@ module.exports = {
 
 /**
  * @param {AwsWrapper} aws
- * @param {string} projectId
  * @param {string} deployment
+ * @param {Array.<string>} instanceIds
  * @returns {function(): Promise}
  */
-function stageDeployment(aws, projectId, deployment) {
-  const list = vm.listDeployment(aws, projectId, deployment);
+function stageDeployment(aws, deployment, instanceIds) {
   
   function promiseToStageDeployment() {
-    return list()
-      .then((instances) => addTags(aws, instances, [
-        tag.createDeployment(deployment)
-      ])());
+    return addTags(aws, instanceIds, [
+      tag.createDeployment(deployment)
+    ])();
   }
   return promiseToStageDeployment;
 }
 
 /**
  * @param {AwsWrapper} aws
- * @param {string} projectId
  * @param {string} pr
+ * @param {Array.<string>} instanceIds
  * @returns {function(): Promise}
  */
-function stagePr(aws, projectId, pr) {
-  const list = vm.listPr(aws, projectId, pr);
+function stagePr(aws, pr, instanceIds) {
 
   function promiseToStagePr() {
-    return list()
-      .then((instances) => addTags(aws, instances, [
-        tag.createPr(pr)
-      ])());
+    return addTags(aws, instanceIds, [
+      tag.createPr(pr)
+    ])();
   }
   return promiseToStagePr;
 }

--- a/src/aws/ec2/vm/vm-ecs.spec.js
+++ b/src/aws/ec2/vm/vm-ecs.spec.js
@@ -185,12 +185,12 @@ describe('AWS: EC2: VM-ECS (ec2 virtual machines for ECS hosting)', () => {
 
   describe('stageDeployment', () => {
     it('should return a function', () => {
-      expect(typeof vme.stageDeployment(aws, 'project', 'master'))
+      expect(typeof vme.stageDeployment(aws, 'deployment', ['instanceId']))
         .to.equal('function');
     });
     
     it('s result function should return a promise', () => {
-      const p = vme.stageDeployment(aws, 'project', 'master')();
+      const p = vme.stageDeployment(aws, 'deployment', ['instanceId'])();
       expect(typeof p.then).to.equal('function');
     });
   });
@@ -209,12 +209,12 @@ describe('AWS: EC2: VM-ECS (ec2 virtual machines for ECS hosting)', () => {
   
   describe('stagePr', () => {
     it('should return a function', () => {
-      expect(typeof vme.stagePr(aws, 'project', '555'))
+      expect(typeof vme.stagePr(aws, '555', ['instanceId']))
         .to.equal('function');
     });
     
     it('s result function should return a promise', () => {
-      const p = vme.stagePr(aws, 'project', '555')();
+      const p = vme.stagePr(aws, '555', ['instanceId'])();
       expect(typeof p.then).to.equal('function');
     });
   });

--- a/src/aws/taskServiceManager.js
+++ b/src/aws/taskServiceManager.js
@@ -20,7 +20,7 @@ function getTaskServiceManager(ecs) {
 
   function listServices(clusterArn) {
     if (!clusterArn) {
-      throw 'Requires cluster ARN';
+      throw new Error('Requires cluster ARN');
     }
 
     const params = {
@@ -216,8 +216,9 @@ function getTaskServiceManager(ecs) {
   }
 
   return {
+    create: createTasksAndServicesOnCluster,
     destroy: deleteAllServicesOnCluster,
-    create: createTasksAndServicesOnCluster
+    list: listServices
   };
 }
 


### PR DESCRIPTION
-  Handling connection draining during the flip is _not_ currently done gracefully.  This hasn't been a problem for basic HTTP html tests but it will be for some applications with stateful servers
- Service with background daemons of their own or long running commands will also face issues across flips
- ECS system has no tags to compensate the hack uses an alternate "-alt" name

#333 works towards the ECS features needed for proper ECS ZDU