### PR TITLE
Add method for retrieving HostedZone records

### DIFF
--- a/src/aws/route53Manager.js
+++ b/src/aws/route53Manager.js
@@ -352,6 +352,18 @@ function getRoute53(route53, zoneId) {
   }
 
   /**
+   * @returns {Promise}
+   */
+  function listZoneRecords() {
+    const params = {
+      HostedZoneId: zoneId
+    };
+    return route53.listResourceRecordSets(params).then(records => {
+      return records.ResourceRecordSets;
+    });
+  }
+
+  /**
     @return {Promise<string>}
   */
   function findId() {
@@ -371,6 +383,7 @@ function getRoute53(route53, zoneId) {
 
 return {
   list,
+  listZoneRecords,
   createPRARecord,
   createPRCNameRecord,
   createDeploymentARecord,


### PR DESCRIPTION
Adds an API call that could be used by the CLI for #255 

CNAME records point to deployed PR/branch

```
r53.listZoneRecords().then(result => {
  const cnameRecords = result.filter(record => record.Type === 'CNAME')
    .map(record => {
      return {
        host: record.Name,
        target: record.ResourceRecords[0].Value
      }
    });
```

Gives you...

```
[
  { 
    host: 'project.clusternator.io.',
    target: 'project-123456789.us-east-1.elb.amazonaws.com'
  },
  { 
    host: 'project-branch.clusternator.io.',
    target: 'project-branch-123456789.us-east-1.elb.amazonaws.com'
  },
  { 
    host: 'project-pr-123.clusternator.io.',
    target: 'project-pr-123-123456789.us-east-1.elb.amazonaws.com'
  }
]
```

Connected to #255
