### PR TITLE
Merging to master will no longer throw errors on test

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -14,10 +14,10 @@ dependencies:
     - cp ./.clusternator/.clusternator-config.json ~/
 
 
-deployment:
-  hub:
-    branch: master
-    commands:
-      - npm run build
-      - ./bin/clusternator.sh read-private -p $CLUSTERNATOR_GPG_KEY
-      - node .clusternator/docker-build.js
+# deployment:
+#  hub:
+#    branch: master
+#    commands:
+#      - npm run build
+#      - ./bin/clusternator.sh read-private -p $CLUSTERNATOR_GPG_KEY
+#      - node .clusternator/docker-build.js


### PR DESCRIPTION
This comments out the deployment code that was breaking the build on master.  This is not necessarily an optimal solution though.  In theory this _should_ work given the current deployment scripts there are at least two obstacles that I know of to getting this working, one may not be readily solvable

- (easy to solve) The Clusternator project needs a `clusternator project create-data` run on it to generate the relevant keys which (I really hope!) contains the `.private/clusternator-aws.json` stuff that _future_ stories will eventually replace
- (maybe not readily solvable) Can we use environment variables on public GitHub/CircleCI projects and is it safe?

@rafkhan what do you think?