### PR TITLE
Updates Route53 to use UPSERT fixes #327

### DIFF
--- a/src/aws/route53Manager.js
+++ b/src/aws/route53Manager.js
@@ -143,7 +143,7 @@ function getRoute53(route53, zoneId) {
     @param {Object=} config
   */
   function createRecordParams(domainName, ip, tld, type, config) {
-    return changeRecordParams('CREATE', domainName, ip, tld, type, config);
+    return changeRecordParams('UPSERT', domainName, ip, tld, type, config);
   }
 
   /**


### PR DESCRIPTION
I had a few short minutes free and I figured I'd try a six character change to attempt to fix #327 (CNAME Error) and it works.  Huzzah, nice and easy.